### PR TITLE
Fetching All FileSystemItems, Navigation Between Directories, and Opening Files in a New Tab

### DIFF
--- a/client/src/api/fileSystemApi.ts
+++ b/client/src/api/fileSystemApi.ts
@@ -5,6 +5,10 @@ type uploadFileSytemItemResponse = {
   fileItem: Object;
 }
 
+type allItemChildrenResponse = {
+  allChildren: object
+}
+
 /**
  * This function takes in all the necessary parameters and sends a
  * POST request to create a new FileSystemItem and saved the image
@@ -18,7 +22,7 @@ type uploadFileSytemItemResponse = {
  * @param parentId - THe id of the parent FileSystemItem.
  * @returns 
  */
-const uploadFileSystemItel = async (
+const uploadFileSystemItem = async (
   userId: string,
   classId: string,
   file: File | null,
@@ -42,8 +46,39 @@ const uploadFileSystemItel = async (
   }
 }
 
+/**
+ * This function takes in the id of the current directory and sends
+ * a GET request to collect all children. The children are either a
+ * folder or a file, with the path to the file from the GCP bucket.
+ * 
+ * @param userId - The id of the user.
+ * @param classId - The id of the current class.
+ * @param parentId - The id of the item to fetch the children from.
+ * @returns - All current children from the parent.
+ */
+const getAllChidrenFromItemId = async (
+  userId: string,
+  classId: string,
+  parentId: string
+): Promise<[any | null, boolean, string]> => {
+  try {
+    const response = await axiosClient.get<allItemChildrenResponse>(
+      `/api/${userId}/class/${classId}/filesystem/${parentId}`,
+      { headers: { 'Content-Type': 'application/json' },
+        withCredentials: true 
+      }
+    )
+    const allChildren: any = response.data.allChildren
+    return [allChildren, true, "Successfulyy fetched all children"]
+  } catch (error) {
+    console.error(error)
+    return [null, false, "Failed to fetch all children"]
+  }
+}
+
 const fileSystemApi = {
-  uploadFileSystemItel
+  uploadFileSystemItem,
+  getAllChidrenFromItemId
 }
 
 export default fileSystemApi

--- a/client/src/api/fileSystemApi.ts
+++ b/client/src/api/fileSystemApi.ts
@@ -2,7 +2,7 @@ import axiosClient from "./client"
 import { FileType } from "../utils/FileType"
 
 type uploadFileSytemItemResponse = {
-  fileItem: Object;
+  fileSystemItem: any;
 }
 
 type allItemChildrenResponse = {
@@ -11,6 +11,10 @@ type allItemChildrenResponse = {
 
 type FileSystemItemResponse = {
   fileSystemItem: Object
+}
+
+type signedUrlResponse = {
+  signedUrl: Object;
 }
 
 /**
@@ -44,7 +48,7 @@ const uploadFileSystemItem = async (
       formData,
       { withCredentials: true }
     )
-    return response
+    return response.data.fileSystemItem
   } catch (error) {
     console.error(error)
   }
@@ -109,10 +113,40 @@ const getFileSystemItemFromItemId = async (
   }
 }
 
+/**
+ * This api call sends a GET request to get the signedUrl from the
+ * bucket, and returns it to be used to open the file.
+ * 
+ * @param userId - The id of the user sending the request.
+ * @param classId - The id of the class of the FileSystemItem.
+ * @param itemId - The id of to fetch the signedUrl.
+ * @returns 
+ */
+const getSignedUrlForFile = async (
+  userId: string,
+  classId: string,
+  itemId: string
+): Promise<[any | null, boolean, string]> => {
+  try {
+    const response = await axiosClient.get<signedUrlResponse>(
+      `/api/${userId}/class/${classId}/filesystem/${itemId}/url`,
+      { headers: { 'Content-Type': 'application/json' },
+        withCredentials: true 
+      }
+    )
+    const signedUrl = response.data.signedUrl
+    return [signedUrl, true, "Url was successfully fetched"]
+  } catch (error) {
+    console.error(error)
+    return [null, false, "Failed to fetch the url"]
+  }
+}
+
 const fileSystemApi = {
   uploadFileSystemItem,
   getAllChidrenFromItemId,
-  getFileSystemItemFromItemId
+  getFileSystemItemFromItemId,
+  getSignedUrlForFile
 }
 
 export default fileSystemApi

--- a/client/src/api/fileSystemApi.ts
+++ b/client/src/api/fileSystemApi.ts
@@ -6,7 +6,11 @@ type uploadFileSytemItemResponse = {
 }
 
 type allItemChildrenResponse = {
-  allChildren: object
+  allChildren: Object
+}
+
+type FileSystemItemResponse = {
+  fileSystemItem: Object
 }
 
 /**
@@ -20,7 +24,7 @@ type allItemChildrenResponse = {
  * @param fileName - The desired file name in the db and the bucket.
  * @param fileType - Folder or File.
  * @param parentId - THe id of the parent FileSystemItem.
- * @returns 
+ * @returns - The new uploaded file.
  */
 const uploadFileSystemItem = async (
   userId: string,
@@ -63,22 +67,52 @@ const getAllChidrenFromItemId = async (
 ): Promise<[any | null, boolean, string]> => {
   try {
     const response = await axiosClient.get<allItemChildrenResponse>(
-      `/api/${userId}/class/${classId}/filesystem/${parentId}`,
+      `/api/${userId}/class/${classId}/filesystem/${parentId}/children`,
       { headers: { 'Content-Type': 'application/json' },
         withCredentials: true 
       }
     )
     const allChildren: any = response.data.allChildren
-    return [allChildren, true, "Successfulyy fetched all children"]
+    return [allChildren, true, "Successfully fetched all children"]
   } catch (error) {
     console.error(error)
     return [null, false, "Failed to fetch all children"]
   }
 }
 
+/**
+ * This api call sends a GET request to get all the attributes from the
+ * desired FileSystemItem. 
+ * 
+ * @param userId - The id of the user sending the request.
+ * @param classId - The id of the class of the FileSystemItem.
+ * @param itemId - The id of the desired FileSystemItem.
+ * @returns - The fetched FileSystemItem.
+ */
+const getFileSystemItemFromItemId = async (
+  userId: string,
+  classId: string,
+  itemId: string,
+): Promise<[any | null, boolean, string]> => {
+  try {
+    const response = await axiosClient.get<FileSystemItemResponse>(
+      `/api/${userId}/class/${classId}/filesystem/${itemId}/`,
+      { headers: { 'Content-Type': 'application/json' },
+        withCredentials: true 
+      }
+    )
+    const fileSystemItem = response.data.fileSystemItem
+    return [fileSystemItem, true, "Successfully fetched the desired item"]
+  } catch (error) {
+    console.error(error)
+    return [null, false, "Failed to fetch the desired item"]
+  }
+}
+
 const fileSystemApi = {
   uploadFileSystemItem,
-  getAllChidrenFromItemId
+  getAllChidrenFromItemId,
+  getFileSystemItemFromItemId
 }
 
 export default fileSystemApi

--- a/client/src/components/ClassroomsGrid.tsx
+++ b/client/src/components/ClassroomsGrid.tsx
@@ -56,6 +56,7 @@ const ClassroomsGrid = () => {
     const [classDetails, status, message] = await classesApi.getClassDetails(userId, classId)
     status ? (() => {
       setCurrClass(classDetails)
+      
       navigate(`/${userId}/classrooms/${classId}/files`) 
     })() : setErrorMessage(message)
   }

--- a/client/src/components/FileItemModal.tsx
+++ b/client/src/components/FileItemModal.tsx
@@ -8,10 +8,11 @@ import useClassroom from '../hooks/useClassroom'
 import '../styles/class-modal.css'
 
 interface addFileItemProps {
-  setToggleAddItemForm: React.Dispatch<React.SetStateAction<boolean>>
+  setToggleAddItemForm: React.Dispatch<React.SetStateAction<boolean>>;
+  setCurrItemChildren: React.Dispatch<React.SetStateAction<any>>;
 }
 
-const FileItemModal = ({setToggleAddItemForm}: addFileItemProps) => {
+const FileItemModal = ({setToggleAddItemForm, setCurrItemChildren}: addFileItemProps) => {
   const [errorMessage, setErrorMessage] = useState<string>('')
   const [newFileName, setNewFileName] = useState<string>('')
   const [fileType, setFileType] = useState<string>('')
@@ -38,7 +39,8 @@ const FileItemModal = ({setToggleAddItemForm}: addFileItemProps) => {
   /**
    * This function uses all the states that were updated based off the
    * form and sends them through the fileSystemApi to make the POST request
-   * that creates the FileSystemItem and adds it to the bucket.
+   * that creates the FileSystemItem and adds it to the bucket, sends another
+   * GET request to refresh the list.
    * 
    * @param event - Prevents default behavior of page reloading after
    * form submission.
@@ -49,7 +51,7 @@ const FileItemModal = ({setToggleAddItemForm}: addFileItemProps) => {
       let formFileType: FileType
       if (fileType === "Folder") { formFileType = FileType.Folder }
       else { formFileType = FileType.File}
-      const response = await fileSystemApi.uploadFileSystemItem(
+      const newFileSystemItem = await fileSystemApi.uploadFileSystemItem(
         userId,
         currClass.id,
         file,
@@ -57,6 +59,14 @@ const FileItemModal = ({setToggleAddItemForm}: addFileItemProps) => {
         formFileType,
         currFileItem.id
       )
+      if (newFileSystemItem) {
+        const [allChildren, status, message] = await fileSystemApi.getAllChidrenFromItemId(
+          userId,
+          currClass.id,
+          currFileItem.id,
+        )
+        status ? setCurrItemChildren(allChildren) : setErrorMessage(message)
+      }
     }
     setToggleAddItemForm(false)
   }

--- a/client/src/components/FileItemModal.tsx
+++ b/client/src/components/FileItemModal.tsx
@@ -18,7 +18,7 @@ const FileItemModal = ({setToggleAddItemForm}: addFileItemProps) => {
   const [actualFileName, setActualFileName] = useState<string>('')
   const [file, setFile] = useState<File | null>(null)
   const { userId } = useAuth()
-  const { currClass } = useClassroom()
+  const { currClass, currFileItem } = useClassroom()
 
   /**
    * This function handles the change of value in the file input tag,
@@ -55,10 +55,10 @@ const FileItemModal = ({setToggleAddItemForm}: addFileItemProps) => {
         file,
         newFileName,
         formFileType,
-        '1adb6946-eea8-4fe5-ba26-e21f63fa8e56'
+        currFileItem.id
       )
     }
-
+    setToggleAddItemForm(false)
   }
 
   return (

--- a/client/src/components/FileItemModal.tsx
+++ b/client/src/components/FileItemModal.tsx
@@ -49,7 +49,7 @@ const FileItemModal = ({setToggleAddItemForm}: addFileItemProps) => {
       let formFileType: FileType
       if (fileType === "Folder") { formFileType = FileType.Folder }
       else { formFileType = FileType.File}
-      const response = await fileSystemApi.uploadFileSystemItel(
+      const response = await fileSystemApi.uploadFileSystemItem(
         userId,
         currClass.id,
         file,

--- a/client/src/components/FileSystemItem.tsx
+++ b/client/src/components/FileSystemItem.tsx
@@ -5,6 +5,7 @@ import fileSystemApi from '../api/fileSystemApi'
 import useAuth from '../hooks/useAuth'
 import useClassroom from '../hooks/useClassroom'
 import '../styles/file-system.css'
+import { FileType } from '../utils/FileType'
 
 interface fileSytemItemProps {
   props: any;
@@ -16,18 +17,27 @@ const FileSystemItem = ({props, setCurrItemChildren}: fileSytemItemProps) => {
   const { currClass, currFileItem, setCurrFileItem } = useClassroom()
   const { userId } = useAuth()
 
-  const handleItemNavigation = async () => {
-    setCurrFileItem(props)
-    const [allChildren, status, message] = await fileSystemApi.getAllChidrenFromItemId(
-      userId,
-      currClass.id,
-      props.id,
-    )
-    status ? setCurrItemChildren(allChildren) : setErrorMessage(message)
+  const handleItemClick = async () => {
+    if (props.type === FileType.Folder) {
+      setCurrFileItem(props)
+      const [allChildren, status, message] = await fileSystemApi.getAllChidrenFromItemId(
+        userId,
+        currClass.id,
+        props.id,
+      )
+      status ? setCurrItemChildren(allChildren) : setErrorMessage(message)
+    } else {
+      const [url, status, message] = await fileSystemApi.getSignedUrlForFile(
+        userId,
+        currClass.id,
+        props.id
+      )
+      status ? window.open(url, '_blank') : setErrorMessage(message)
+    }
   }
 
   return (
-    <div className='file-system-item' onClick={handleItemNavigation}>
+    <div className='file-system-item' onClick={handleItemClick}>
       <div className='file-system-item-icon-conatiner'>
           <FontAwesomeIcon size='lg' icon={props.type === "Folder" ? faFolder : faFile}/>
       </div>

--- a/client/src/components/FileSystemItem.tsx
+++ b/client/src/components/FileSystemItem.tsx
@@ -16,9 +16,6 @@ const FileSystemItem = ({props, setCurrItemChildren}: fileSytemItemProps) => {
   const { currClass, currFileItem, setCurrFileItem } = useClassroom()
   const { userId } = useAuth()
 
-  /**
-   * 
-   */
   const handleItemNavigation = async () => {
     setCurrFileItem(props)
     const [allChildren, status, message] = await fileSystemApi.getAllChidrenFromItemId(

--- a/client/src/components/FileSystemItem.tsx
+++ b/client/src/components/FileSystemItem.tsx
@@ -1,14 +1,36 @@
+import { useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFolder, faFile } from '@fortawesome/free-solid-svg-icons'
+import fileSystemApi from '../api/fileSystemApi'
+import useAuth from '../hooks/useAuth'
+import useClassroom from '../hooks/useClassroom'
 import '../styles/file-system.css'
 
-type fileSytemItemProps = {
-  props: any
+interface fileSytemItemProps {
+  props: any;
+  setCurrItemChildren: React.Dispatch<React.SetStateAction<any>>;
 }
 
-const FileSystemItem = ({props}: fileSytemItemProps) => {
+const FileSystemItem = ({props, setCurrItemChildren}: fileSytemItemProps) => {
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const { currClass, currFileItem, setCurrFileItem } = useClassroom()
+  const { userId } = useAuth()
+
+  /**
+   * 
+   */
+  const handleItemNavigation = async () => {
+    setCurrFileItem(props)
+    const [allChildren, status, message] = await fileSystemApi.getAllChidrenFromItemId(
+      userId,
+      currClass.id,
+      props.id,
+    )
+    status ? setCurrItemChildren(allChildren) : setErrorMessage(message)
+  }
+
   return (
-    <div className='file-system-item'>
+    <div className='file-system-item' onClick={handleItemNavigation}>
       <div className='file-system-item-icon-conatiner'>
           <FontAwesomeIcon size='lg' icon={props.type === "Folder" ? faFolder : faFile}/>
       </div>

--- a/client/src/components/FileSystemItem.tsx
+++ b/client/src/components/FileSystemItem.tsx
@@ -1,0 +1,22 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faFolder, faFile } from '@fortawesome/free-solid-svg-icons'
+import '../styles/file-system.css'
+
+type fileSytemItemProps = {
+  props: any
+}
+
+const FileSystemItem = ({props}: fileSytemItemProps) => {
+  return (
+    <div className='file-system-item'>
+      <div className='file-system-item-icon-conatiner'>
+          <FontAwesomeIcon size='lg' icon={props.type === "Folder" ? faFolder : faFile}/>
+      </div>
+      <div className='file-system-item-name'>
+        <h3>{props.name}</h3>
+      </div>
+    </div>
+  ) 
+}
+
+export default FileSystemItem

--- a/client/src/components/FilesDisplay.tsx
+++ b/client/src/components/FilesDisplay.tsx
@@ -1,15 +1,42 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useReducer, useRef, useState } from 'react'
 import FileItemModal from './FileItemModal'
 import '../styles/file-system.css'
 import useClassroom from '../hooks/useClassroom'
+import fileSystemApi from '../api/fileSystemApi'
+import useAuth from '../hooks/useAuth'
+import FileSystemItem from './FileSystemItem'
 
 const FilesDisplay = () => {
   const [toggleAddItemForm, setToggleAddItemForm] = useState<boolean>(false)
+  const [currItemChildren, setCurrItemChildren] = useState<any>()
+  const [errorMessage, setErrorMessage] = useState<string>('')
+  const { userId } = useAuth()
   const { currClass, currFileItem, setCurrFileItem } = useClassroom()
+  const initialRender = useRef(true)
 
+  /**
+   * Updates the current file item to the root based off the class id on reload.
+   */
   useEffect(() => {
     setCurrFileItem(currClass.rootFile)
   }, [currClass])
+
+  /**
+   * Fetches all the children from the root file of the class on render, sets
+   * them to a state if successful. If the fetch from the fileSystemApi was 
+   * not successful, the error message is also stored in a state.
+   */
+  useEffect(() => {
+    const fetchAllChildren = async () => {
+      const [allChildren, status, message] = await fileSystemApi.getAllChidrenFromItemId(
+        userId,
+        currClass.id,
+        currFileItem.id,
+      )
+      status ? setCurrItemChildren(allChildren) : setErrorMessage(message)
+    }
+    if (initialRender.current) { initialRender.current = false } else { fetchAllChildren() }
+  }, [currFileItem])
 
   return (
     <div className="file-system-grid">
@@ -19,6 +46,11 @@ const FilesDisplay = () => {
         <button onClick={() => setToggleAddItemForm(true)} className='file-system-grid-button'>Add New Item</button>
       </div>
       <hr style={{marginTop: '10px'}}/>
+      <div className='file-system-grid-container'>
+        {currItemChildren ? currItemChildren.map((item: any, key: any) => (
+          <FileSystemItem key={key} props={item} />
+        )) : []}
+      </div>
     </div>
   )
 }

--- a/client/src/components/FilesDisplay.tsx
+++ b/client/src/components/FilesDisplay.tsx
@@ -17,7 +17,12 @@ const FilesDisplay = () => {
   const { currClass, currFileItem, setCurrFileItem } = useClassroom()
 
   /**
-   * Updates the current file item to the root based off the class id on reload.
+   * This function takes in the itemId and fetches both all the children
+   * to render as components and the rest of the information from the item
+   * to store in the useClassroom.
+   * 
+   * @param itemId - The item id to fetch all the children from and to 
+   * fetch the rest of its information.
    */
   const fetchAllChildren = async (itemId: string) => {
     const [allChildren, status, message] = await fileSystemApi.getAllChidrenFromItemId(
@@ -54,30 +59,30 @@ const FilesDisplay = () => {
 
   return (
     (!loading && (
-<div className="file-system-grid">
-      {toggleAddItemForm ? <FileItemModal setToggleAddItemForm={setToggleAddItemForm}/> : []}
-      <div style={{display: 'flex', justifyContent: 'space-between'}}>
-        <div style={{display: 'flex', alignItems: 'center', gap: '1.5vw'}}>
-          <h1 className='file-system-grid-title'>File System</h1>
+      <div className="file-system-grid">
+        {toggleAddItemForm ? <FileItemModal setToggleAddItemForm={setToggleAddItemForm} setCurrItemChildren={setCurrItemChildren} /> : []}
+        <div style={{display: 'flex', justifyContent: 'space-between'}}>
+          <div style={{display: 'flex', alignItems: 'center', gap: '1.5vw'}}>
+            <h1 className='file-system-grid-title'>File System</h1>
+          </div>
+          <button onClick={() => setToggleAddItemForm(true)} className='file-system-grid-button'>Add New Item</button>
         </div>
-        <button onClick={() => setToggleAddItemForm(true)} className='file-system-grid-button'>Add New Item</button>
+        <hr style={{marginTop: '10px'}}/>
+        <div style={{display: 'flex', alignItems: 'center', gap: '1vw', padding: '4vh 0 0 0'}}>
+          {(currFileItem && currFileItem.classId === null) && (
+            <>
+              <FontAwesomeIcon onClick={() => fetchAllChildren(currFileItem.parentId)} size='lg' icon={faArrowLeftLong}/>
+              <h3>|</h3>
+            </>
+          )}
+          <h3>Current Directory: {currFileItem.name}</h3>
+        </div>
+        <div className='file-system-grid-container'>
+          {(currItemChildren && currItemChildren.length > 0) ? currItemChildren.map((item: any, key: any) => (
+            <FileSystemItem key={key} props={item} setCurrItemChildren={setCurrItemChildren} />
+          )) : <h4>No files or folders in this directory</h4>}
+        </div>
       </div>
-      <hr style={{marginTop: '10px'}}/>
-      <div style={{display: 'flex', alignItems: 'center', gap: '1vw', padding: '4vh 0 0 0'}}>
-        {(currFileItem && currFileItem.classId === null) && (
-          <>
-            <FontAwesomeIcon onClick={() => fetchAllChildren(currFileItem.parentId)} size='lg' icon={faArrowLeftLong}/>
-            <h3>|</h3>
-          </>
-        )}
-        <h3>Current Directory: {currFileItem.name}</h3>
-      </div>
-      <div className='file-system-grid-container'>
-        {(currItemChildren && currItemChildren.length > 0) ? currItemChildren.map((item: any, key: any) => (
-          <FileSystemItem key={key} props={item} setCurrItemChildren={setCurrItemChildren} />
-        )) : <h4>No files or folders in this directory</h4>}
-      </div>
-    </div>
     ))
     
   )

--- a/client/src/components/FilesDisplay.tsx
+++ b/client/src/components/FilesDisplay.tsx
@@ -1,10 +1,15 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import FileItemModal from './FileItemModal'
 import '../styles/file-system.css'
+import useClassroom from '../hooks/useClassroom'
 
 const FilesDisplay = () => {
-
   const [toggleAddItemForm, setToggleAddItemForm] = useState<boolean>(false)
+  const { currClass, currFileItem, setCurrFileItem } = useClassroom()
+
+  useEffect(() => {
+    setCurrFileItem(currClass.rootFile)
+  }, [currClass])
 
   return (
     <div className="file-system-grid">

--- a/client/src/context/ClassroomContext.tsx
+++ b/client/src/context/ClassroomContext.tsx
@@ -4,7 +4,9 @@ type ClassroomContextType = {
   isClassroom: boolean
   setIsClassroom: React.Dispatch<React.SetStateAction<boolean>>
   currClass: any
-  setCurrClass: React.Dispatch<React.SetStateAction<any>>
+  setCurrClass: React.Dispatch<React.SetStateAction<any>>;
+  currFileItem: any;
+  setCurrFileItem: React.Dispatch<React.SetStateAction<any>>;
 }
 
 const ClassroomContext = createContext<ClassroomContextType | undefined>(undefined)
@@ -26,6 +28,11 @@ export const ClassroomProvider = ({ children }: ClassroomContextChildren) => {
     return stored ? JSON.parse(stored) : null
   })
 
+  const [currFileItem, setCurrFileItem] = useState<any>(() => {
+    const stored = localStorage.getItem('currFileItem')
+    return stored ? JSON.parse(stored): null
+  })
+
   useEffect(() => {
     localStorage.setItem('isClassroom', String(isClassroom))
   }, [isClassroom])
@@ -38,12 +45,22 @@ export const ClassroomProvider = ({ children }: ClassroomContextChildren) => {
     }
   }, [currClass])
 
+  useEffect(() => {
+    if (currFileItem) {
+      localStorage.setItem('currFileItem', JSON.stringify(currFileItem))
+    } else {
+      localStorage.removeItem('currFileItem')
+    }
+  }, [currFileItem])
+
   const value = useMemo(() => ({
     isClassroom,
     setIsClassroom,
     currClass,
-    setCurrClass
-  }), [isClassroom, currClass])
+    setCurrClass,
+    currFileItem,
+    setCurrFileItem
+  }), [isClassroom, currClass, currFileItem])
 
   return (
     <ClassroomContext.Provider value={value}>

--- a/client/src/styles/file-system.css
+++ b/client/src/styles/file-system.css
@@ -19,3 +19,7 @@
   border: 1px solid var(--textColor);
   border-radius: 5px;
 }
+
+.file-system-grid-container {
+  padding: 50px 0;
+}

--- a/client/src/styles/file-system.css
+++ b/client/src/styles/file-system.css
@@ -21,7 +21,7 @@
 }
 
 .file-system-grid-container {
-  padding: 50px 0;
+  padding: 4vh 0;
   display: flex;
   flex-direction: column;
 }

--- a/client/src/styles/file-system.css
+++ b/client/src/styles/file-system.css
@@ -22,4 +22,38 @@
 
 .file-system-grid-container {
   padding: 50px 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.file-system-item {
+  width: 100%;
+  height: 8vh;
+  padding: 0 2vw;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  gap: 2vw;
+  background-color: #2E3543;
+  border: 1px solid #959595;
+  cursor: pointer
+}
+
+.file-system-item:hover {
+  background-color: #282e3b;
+}
+
+.file-system-item-icon-conatiner {
+  height: 100%;
+  width: 2vw;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.file-system-item-name {
+  height: 100%;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
 }

--- a/server/src/classes/classes.services.ts
+++ b/server/src/classes/classes.services.ts
@@ -2,6 +2,7 @@ import classroomUtils from "./classes.utils"
 import { Context } from '../context/context'
 import { FileType } from "@prisma/client"
 import fileSystemServices from "../filesystem/filesystem.services"
+import fileSystemUtil from "../filesystem/filesystem.utils"
 
 /**
  * This function takes in a class id and uses
@@ -146,13 +147,14 @@ const createClass = async (
     }
   })
   await fileSystemServices.createFileSystemItem(
-    '/',
-    '/',
+    `${sectionId}_root`,
+    `file_system/${sectionId}_root/`,
     FileType.Folder,
     null,
     newClass.id,
     ctx
   )
+  await fileSystemUtil.addFolderToFileSystem(`file_system/${sectionId}_root/`)
   await ctx.prisma.user.update({
     where: {
       id: professorId

--- a/server/src/classes/classes.services.ts
+++ b/server/src/classes/classes.services.ts
@@ -226,6 +226,9 @@ const findClassByUserIdAndClassId = async (
             id: studentId
           }
         }
+      },
+      include: {
+        rootFile: true
       }
     })
   } else if (professorId) {
@@ -235,6 +238,9 @@ const findClassByUserIdAndClassId = async (
         professor: {
           id: professorId
         }
+      },
+      include: {
+        rootFile: true
       }
     })
   }

--- a/server/src/filesystem/filesystem.routes.ts
+++ b/server/src/filesystem/filesystem.routes.ts
@@ -77,4 +77,27 @@ router.post('/:userId/class/:classId/filesystem', upload.single('file'), authent
   }
 })
 
+/**
+ * This route is a GET request that uses the id of the current FileSystemItem
+ * to get all of its children. It also checks if the root of the item id is
+ * in the same classs as the one in the route.
+ */
+router.get('/:userId/class/:classId/filesystem/:parentId',authenticateToken, async (req, res, next) => {
+  try {
+    const classId = req.params.classId
+    const parentId = req.params.parentId
+
+    const rootFileSystemItem = await fileSystemServices.findRootFileSystemItem(parentId, ctx)
+    if (rootFileSystemItem?.classId !== classId) {
+      res.status(400).json({message: "Root directory is not connected to the same class or any class"})
+      throw new Error('Root directory is not connected to the same class or any class')
+    }
+
+    const allFileSystemItemChildren = await fileSystemServices.findAllChidrenForFileSystemItem(parentId, ctx)
+    res.status(200).json({allChildren: allFileSystemItemChildren})
+  } catch (error) {
+    console.error(error)
+  }
+})
+
 export default router

--- a/server/src/filesystem/filesystem.services.ts
+++ b/server/src/filesystem/filesystem.services.ts
@@ -46,6 +46,9 @@ const findFileSystemItemById = async (id: string, ctx: Context) => {
   return await ctx.prisma.fileSystemItem.findUnique({
     where: {
       id
+    },
+    include: {
+      children: true
     }
   })
 }

--- a/server/src/filesystem/filesystem.services.ts
+++ b/server/src/filesystem/filesystem.services.ts
@@ -66,10 +66,39 @@ const findAllChidrenForFileSystemItem = async (id: string, ctx: Context) => {
   })
 }
 
+/**
+ * This function takes in the currId of the FileSystemItem and uses it to
+ * continuously navigate until the root FileSystemItem and returns it.
+ * 
+ * @param currId - The id of the current FileSystemItem
+ * @param ctx - The prisma context that this function is being used in.
+ * @returns 
+ */
+const findRootFileSystemItem = async (currId: string, ctx: Context) => {
+  let currentFileSystemItem = await ctx.prisma.fileSystemItem.findUnique({
+    where: {
+      id: currId
+    }
+  })
+
+  while (currentFileSystemItem?.parentId) {
+    currentFileSystemItem = await ctx.prisma.fileSystemItem.findUnique({
+      where: {
+        id: currentFileSystemItem.parentId
+      },
+      include: {
+        parent: true
+      }
+    })
+  }
+  return currentFileSystemItem
+}
+
 const fileSystemServices = {
   createFileSystemItem,
   findFileSystemItemById,
-  findAllChidrenForFileSystemItem
+  findAllChidrenForFileSystemItem,
+  findRootFileSystemItem
 }
 
 export default fileSystemServices


### PR DESCRIPTION
This pull request completes the files page by adding components that display each FileSystemItem. There has also been the addition of navigating between folders and the ability to open files in a separate tab.

This Pull Request:
- Adds two GET requests, one that returns the FileSystemItems based off id, and the other returns the signedUrl that allows the client to access the file.
- Updated service files to support navigation, also changed how the routes are declared when creating new FileSytemItems and how the root directory of a class is handled.
- Added a back arrow that allows you go to back one directory level, and clicking folders display all children.
- Clicking a file will open up the desired file in the right format in the next tab.

Upcoming Changes:
- Unit tests for all of the new service files, and most likely edit previous tests to fit new root directory changes.
- Begin creating routes and service files for the assignments and setting up the bucket for file uploads in the assignments.

Google Cloud Provider Bucket:
<img width="1259" alt="Screenshot 2025-07-03 at 4 56 26 PM" src="https://github.com/user-attachments/assets/723d60d6-f60d-456a-bf71-97fc02ce2119" />

Video:
https://github.com/user-attachments/assets/a2ea27a7-415b-429f-95c1-59535535941d