### PR TITLE
Assignments And Submissions Setup & File Management

### DIFF
--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -95,4 +95,5 @@ model Submission {
   submitted       Boolean
   submissionTime  DateTime?
   uploadedFiles   String[]
+  @@unique([assignmentId, studentId])
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -25,6 +25,7 @@ model User {
   updatedAt         DateTime        @updatedAt
   studentClasses    Classes[]       @relation("studentClasses")
   professorClasses  Classes[]       @relation("professorClasses")
+  submissions       Submission[]    @relation("studentSubmission")
 }
 
 enum UserRole {
@@ -54,6 +55,7 @@ model Classes {
   professor    User             @relation("professorClasses", fields: [professorId], references: [id])
   students     User[]           @relation("studentClasses")
   rootFile     FileSystemItem?  @relation("classRootFile")
+  assignments  Assignment[]     @relation("classAssignments")
 }
 
 enum FileType {
@@ -71,4 +73,26 @@ model FileSystemItem {
   parent    FileSystemItem?   @relation("FileToFile", fields: [parentId], references: [id])
   fileURL   String?
   children  FileSystemItem[] @relation("FileToFile")
+}
+
+model Assignment {
+  id           String        @id @unique @default(uuid())
+  classId      String
+  class        Classes       @relation("classAssignments", fields: [classId], references: [id])
+  name         String 
+  description  String
+  dueDate      DateTime
+  files        String[]
+  submissions  Submission[]  @relation("assignmentSubmissions")
+}
+
+model Submission {
+  id              String      @id @unique @default(uuid())
+  assignmentId    String
+  assignment      Assignment  @relation("assignmentSubmissions", fields: [assignmentId], references: [id])
+  studentId       String
+  student         User        @relation("studentSubmission", fields: [studentId], references: [id])
+  submitted       Boolean
+  submissionTime  DateTime?
+  uploadedFiles   String[]
 }

--- a/server/src/assignments/assignments.routes.ts
+++ b/server/src/assignments/assignments.routes.ts
@@ -1,0 +1,46 @@
+import express from 'express'
+import { prisma } from '../context/context'
+import { authenticateToken } from '../auth/auth.jwt'
+import multer from 'multer'
+import classService from '../classes/classes.services'
+import assignmentUtils from './assignments.utils'
+import assignmentServices from './assignments.services'
+
+const router = express.Router()
+const ctx = { prisma }
+const upload = multer({ dest: 'uploads/assignments'})
+
+/**
+ * This POST route handles the creation of a new assignment in a class. It verifies
+ * if the creator is a professor, it verifies if there are any files associated, 
+ * uploades them to the GCP bucket, and creates the assignment with the rest of the
+ * information provided.
+ */
+router.post('/:userId/class/:classId/assignment', upload.array('uploadedFiles'), authenticateToken, async (req, res, next) => {
+  const { assignmentName, assignmentDescription, dueDate } = req.body
+  const classId = req.params.classId
+  const userId = req.params.userId
+
+  const currClass = await classService.findProfessorByClassId(classId, ctx)
+  if (currClass?.professor.id !== userId) {
+    res.status(400).json({message: "Only the professor of this course can create an assignment"})
+    throw new Error('Only the professor of this course can create an assignment')
+  }
+
+  let filesUrls
+  const files = req.files as Express.Multer.File[]
+  if (files !== undefined && files.length > 0) {
+    filesUrls = await assignmentUtils.uploadAssignmentFiles(files, assignmentName)
+  }
+
+  const newAssignment = await assignmentServices.createNewAssignment(
+    assignmentName,
+    assignmentDescription,
+    classId,
+    dueDate,
+    filesUrls || undefined,
+    ctx
+  )
+
+  res.status(200).json({assignment: newAssignment})
+})

--- a/server/src/assignments/assignments.routes.ts
+++ b/server/src/assignments/assignments.routes.ts
@@ -5,6 +5,10 @@ import multer from 'multer'
 import classService from '../classes/classes.services'
 import assignmentUtils from './assignments.utils'
 import assignmentServices from './assignments.services'
+import submissionServices from './submission.services'
+import authServices from '../auth/auth.services'
+import { UserRole } from '@prisma/client'
+import gcpBucketUtils from '../gcpbucket/gcpbucket.utils'
 
 const router = express.Router()
 const ctx = { prisma }
@@ -43,4 +47,92 @@ router.post('/:userId/class/:classId/assignment', upload.array('uploadedFiles'),
   )
 
   res.status(200).json({assignment: newAssignment})
+})
+
+/**
+ * This POST request uploads files the student inputed into their submissions instance
+ * and also adds them to the GCP bucket. This route does not submit the assignment, but
+ * rather gets the files ready for when the assignment is submitted. This request cannot be
+ * made once the submission is submitted.
+ */
+router.post('/:userId/class/:classId/assignment/:assignmentId/uploadfiles', upload.single('uploadedFiles'), authenticateToken, async (req, res, next) => {
+  const userId = req.params.userId
+  const assignmentId = req.params.assignmentId
+
+  const currSubmission = await submissionServices.findSubmissionWithUserIdAndAssignmentId(
+    userId,
+    assignmentId,
+    ctx
+  )
+
+  if (currSubmission?.submitted === true) {
+    res.status(400).json({message: "Cannot make this request when assignment is already submitted"})
+    throw new Error('Cannot make this request when assignment is already submitted')
+  }
+
+  const currUser = await authServices.findUserById(userId, ctx)
+  if (!currUser || currUser.accountType !== UserRole.Student) {
+    res.status(400).json({message: "User is not a student or does not exist"})
+    throw new Error('User is not a student or does not exist')
+  }
+
+  const file = req.file
+  if (!file) {
+    res.status(400).json({message: "No file sent on request"})
+    throw new Error('No file sent on request')
+  }
+
+  const filePath = file.path
+
+  const submission = await submissionServices.uploadSubmissionFile(
+    userId,
+    assignmentId,
+    filePath,
+    ctx
+  )
+  res.status(200).json({submission: submission})
+})
+
+/**
+ * This DELETE requeest removes the desired filed from the list of uplaoded files from
+ * both the submission instance in the db and also in the GCP bucket. This request cannot
+ * be made once the submission is submitted.
+ */
+router.delete('/:userId/class/:classId/assignment/:assignmentId/uploadfiles', authenticateToken, async (req, res, next) => {
+  const userId = req.params.userId
+  const assignmentId = req.params.assignmentId
+  const { filePath } = req.body
+
+  const currSubmission = await submissionServices.findSubmissionWithUserIdAndAssignmentId(
+    userId,
+    assignmentId,
+    ctx
+  )
+
+  if (currSubmission?.submitted === true) {
+    res.status(400).json({message: "Cannot make this request when assignment is already submitted"})
+    throw new Error('Cannot make this request when assignment is already submitted')
+  }
+
+  const currUser = await authServices.findUserById(userId, ctx)
+  if (!currUser || currUser.accountType !== UserRole.Student) {
+    res.status(400).json({message: "User is not a student or does not exist"})
+    throw new Error('User is not a student or does not exist')
+  }
+
+  await gcpBucketUtils.deleteObjectFromBucket(filePath)
+
+  const updatedSubmission = await submissionServices.deleteSubmissionFile(
+    userId,
+    assignmentId,
+    filePath,
+    ctx
+  )
+
+  if (updatedSubmission === null) {
+    res.status(400).json({message: "Issue removing the file from the submission"})
+    throw new Error('Issue removing the file from the submission')
+  }
+
+  res.status(200).json({submission: updatedSubmission})
 })

--- a/server/src/assignments/assignments.services.ts
+++ b/server/src/assignments/assignments.services.ts
@@ -13,14 +13,13 @@ import submissionServices from "./submission.services"
  * @param dueDate - The date the assignment is due.
  * @param files - Any supporting files needed to complete the assignment.
  * @param ctx - The prisma context that this function is being used in.
- * @returns 
  */
 const createNewAssignment = async (
   assignmentName: string,
   assignmentDescription: string,
   classId: string,
   dueDate: Date,
-  files: string[],
+  files: string[] | undefined,
   ctx: Context
 ) => {
   const classStudents = await classService.findAllStudentsByClassId(classId, ctx)

--- a/server/src/assignments/assignments.services.ts
+++ b/server/src/assignments/assignments.services.ts
@@ -1,0 +1,51 @@
+import { Context } from "../context/context"
+import classService from "../classes/classes.services"
+import submissionServices from "./submission.services"
+
+/**
+ * This function takes in all the necessary information to create a new
+ * assignment. This function also finds all the students in the class
+ * using the classId and makes a submission instance for each one.
+ * 
+ * @param assignmentName - The desired name of the assignment.
+ * @param assignmentDescription - The desired description of the assignment.
+ * @param classId - The classId of the assignment.
+ * @param dueDate - The date the assignment is due.
+ * @param files - Any supporting files needed to complete the assignment.
+ * @param ctx - The prisma context that this function is being used in.
+ * @returns 
+ */
+const createNewAssignment = async (
+  assignmentName: string,
+  assignmentDescription: string,
+  classId: string,
+  dueDate: Date,
+  files: string[],
+  ctx: Context
+) => {
+  const classStudents = await classService.findAllStudentsByClassId(classId, ctx)
+  if (classStudents) {
+    const newAssignemt = await ctx.prisma.assignment.create({
+      data: {
+        name: assignmentName,
+        description: assignmentDescription,
+        classId: classId,
+        dueDate: dueDate,
+        files: files,
+      }
+    })
+    for (const student of classStudents?.students) {
+      await submissionServices.createSubmissionForAssignment(
+        newAssignemt.id,
+        student.id,
+        ctx
+      )
+    }
+  }
+}
+
+const assignmentServices = {
+  createNewAssignment
+}
+
+export default assignmentServices

--- a/server/src/assignments/assignments.utils.ts
+++ b/server/src/assignments/assignments.utils.ts
@@ -1,0 +1,34 @@
+import gcpBucketUtils from '../gcpbucket/gcpbucket.utils'
+import fs from 'fs'
+
+/**
+ * This function takes in all the files needed to complete the assignment,
+ * and stores them in the GCP bucket under a directory using the 
+ * assignment name. Returns a list of all the paths of the uplaoded files. 
+ * 
+ * @param files - The files needed to complete the assignment.
+ * @param assignmentName - The name of the assignment and also the dir name.
+ * @returns - A list with all of the paths of the uploaded files.
+ */
+const uploadAssignmentFiles = async (
+  files: Express.Multer.File[],
+  assignmentName: string,
+) => {
+  let filesUrls = []
+  const folderName = `assignments/${assignmentName}/assignmentFiles/`
+  gcpBucketUtils.addFolderToFileSystem(folderName)
+  for (const file of files) {
+    const fileDestination = folderName + file.originalname
+    const localFilePath = file.path
+    gcpBucketUtils.uploadFileToFileSystem(fileDestination, localFilePath)
+    fs.unlink(localFilePath, (err) => { if (err) { console.error('Failed to delete file', err) } })
+    filesUrls.push(fileDestination)
+  }
+  return filesUrls
+}
+
+const assignmentUtils = {
+  uploadAssignmentFiles
+}
+
+export default assignmentUtils

--- a/server/src/assignments/submission.services.ts
+++ b/server/src/assignments/submission.services.ts
@@ -1,0 +1,30 @@
+import { Context } from "../context/context"
+
+/**
+ * This function takes in the assignmentId and the studentId from the
+ * createNewAssignment function and makes a new submission instance for
+ * that specific student.
+ * 
+ * @param assignmentId - The assignment the submission is related to.
+ * @param studentId - The student the submission belongs to.
+ * @param ctx - The prisma context that this function is being used in.
+ */
+const createSubmissionForAssignment = async (
+  assignmentId: string,
+  studentId: string,
+  ctx: Context
+) => {
+  await ctx.prisma.submission.create({
+    data: {
+      assignmentId: assignmentId,
+      studentId: studentId,
+      submitted: false
+    }
+  })
+}
+
+const submissionServices = {
+  createSubmissionForAssignment
+}
+
+export default submissionServices

--- a/server/src/assignments/submission.services.ts
+++ b/server/src/assignments/submission.services.ts
@@ -23,8 +23,113 @@ const createSubmissionForAssignment = async (
   })
 }
 
+/**
+ * This function returns the submission object using both the assignmentId
+ * and the userId to query the object.
+ * 
+ * @param assignmentId - The assignmentId of the submission instance.
+ * @param studentId - The id of the student of the submission instance
+ * @param ctx - The prisma context that this function is being used in.
+ * @returns - The desired submission object.
+ */
+const findSubmissionWithUserIdAndAssignmentId = async (
+  assignmentId: string,
+  studentId: string,
+  ctx: Context
+) => {
+  return await ctx.prisma.submission.findUnique({
+    where: {
+      assignmentId_studentId: {
+        assignmentId: assignmentId,
+        studentId: studentId
+      }
+    }
+  })
+}
+
+/**
+ * This function uses both the studentId and the assignment to first query
+ * the submission instance and then pushes the new filePath to the list of 
+ * the uploaded file's strings. It then returns the new updated submission
+ * instance.
+ * 
+ * @param assignmentId - The assignmentId of the submission instance.
+ * @param studentId - The id of the student of the submission instance
+ * @param filePath - The filepath of the new file to be uploaded.
+ * @param ctx - The prisma context that this function is being used in.
+ * @returns - The new updated submission object.
+ */
+const uploadSubmissionFile = async (
+  studentId: string,
+  assignmentId: string,
+  filePath: string,
+  ctx: Context
+) => {
+  return await ctx.prisma.submission.update({
+    where: {
+      assignmentId_studentId: {
+        assignmentId: assignmentId,
+        studentId: studentId
+      }
+    },
+    data: {
+      uploadedFiles: {
+        push: filePath
+      }
+    }
+  })
+}
+
+/**
+ * This function updates the uploadedFiles list from the desired submission
+ * instance by deleting the desired filePath from the list, and returning the
+ * new updated submission object.
+ * 
+ * @param assignmentId - The assignmentId of the submission instance.
+ * @param studentId - The id of the student of the submission instance
+ * @param filePath - The filepath of the to be deleted file.
+ * @param ctx - The prisma context that this function is being used in.
+ * @returns - The new updated submission object.
+ */
+const deleteSubmissionFile = async (
+  studentId: string,
+  assignmentId: string,
+  filePath: string,
+  ctx: Context
+): Promise<any> => {
+  const submission = await ctx.prisma.submission.findUnique({
+    where: {
+      assignmentId_studentId: {
+        assignmentId: assignmentId,
+        studentId: studentId
+      }
+    },
+    select: {
+      uploadedFiles: true
+    }
+  })
+  if (submission) {
+    const updatedFiles = submission.uploadedFiles.filter(path => path !== filePath)
+    return await ctx.prisma.submission.update({
+      where: {
+        assignmentId_studentId: {
+          assignmentId: assignmentId,
+          studentId: studentId
+        }
+      },
+      data: {
+        uploadedFiles: updatedFiles
+      }
+    })
+  }
+  return null
+}
+
 const submissionServices = {
-  createSubmissionForAssignment
+  createSubmissionForAssignment,
+  uploadSubmissionFile,
+  deleteSubmissionFile,
+  findSubmissionWithUserIdAndAssignmentId
 }
 
 export default submissionServices

--- a/server/src/filesystem/filesystem.utils.ts
+++ b/server/src/filesystem/filesystem.utils.ts
@@ -2,57 +2,11 @@ import { Storage } from '@google-cloud/storage'
 import path from 'path'
 import dotenv from 'dotenv'
 import fs from 'fs'
+import gcpBucketUtils from '../gcpbucket/gcpbucket.utils'
 
 dotenv.config()
 const storage = new Storage()
 const bucketName: string = process.env.GOOGLE_BUCKET_NAME!
-
-/**
- * This function takes in the desired path in the bucket and the path
- * to the local file and stores the file in the bucket.
- * 
- * @param destinationPath - The path that will be put in the bucket.
- * @param localFilePath - The local file used to access the file.
- */
-const uploadFileToFileSystem = async (destinationPath: string, localFilePath: string) => {
-  const options = {
-    destination: destinationPath,
-  }
-  await storage.bucket(bucketName).upload(localFilePath, options)
-}
-
-/**
- * This function takes the desired folder path for the bucket and
- * places it in the bucket. 
- * 
- * @param folderName - The desired path for the folder in the bucket.
- */
-const addFolderToFileSystem = async (folderPath: string) => {
-  const bucket = storage.bucket(bucketName)
-  const folder = bucket.file(`${folderPath}`)
-  await folder.save('')
-}
-
-/**
- * This generates a url that allows the server to access the private
- * GCB for the next hour.
- * 
- * @param filePath - The path of the desired file in the bucekt..
- */
-const generateV4ReadSignedUrl = async (fileName: string) => {
-  const options = {
-    version: 'v4' as const,
-    action: 'read' as const,
-    expires: new Date(Date.now() + 15 * 60 * 1000),
-  }
-
-  const [url] = await storage
-    .bucket(bucketName)
-    .file(fileName)
-    .getSignedUrl(options)
-
-  return url
-}
 
 /**
  * This function takes in the desired file and file name or just the
@@ -74,7 +28,7 @@ const createNewFileSystemItem = async (
   if (!file) {
     const newFileName = fileSystemItemName + '/'
     const folderPath = `${parentUrl}${newFileName}`
-    await addFolderToFileSystem(folderPath)
+    await gcpBucketUtils.addFolderToFileSystem(folderPath)
     dbFileName = fileSystemItemName
     dbUrl = folderPath
   } else {
@@ -82,7 +36,7 @@ const createNewFileSystemItem = async (
     const newFileName = fileSystemItemName + originalExt
     const localFilePath = file.path
     const destinationPath = `${parentUrl}${newFileName}`
-    await uploadFileToFileSystem(destinationPath, localFilePath)
+    await gcpBucketUtils.uploadFileToFileSystem(destinationPath, localFilePath)
     fs.unlink(localFilePath, (err) => { if (err) { console.error('Failed to delete file', err) } })
     dbFileName = newFileName
     dbUrl = destinationPath
@@ -91,9 +45,6 @@ const createNewFileSystemItem = async (
 }
 
 const fileSystemUtil = {
-  uploadFileToFileSystem,
-  generateV4ReadSignedUrl,
-  addFolderToFileSystem,
   createNewFileSystemItem
 }
 

--- a/server/src/gcpbucket/gcpbucket.utils.ts
+++ b/server/src/gcpbucket/gcpbucket.utils.ts
@@ -1,0 +1,62 @@
+import { Storage } from '@google-cloud/storage'
+import dotenv from 'dotenv'
+
+dotenv.config()
+const storage = new Storage()
+const bucketName: string = process.env.GOOGLE_BUCKET_NAME!
+
+
+/**
+ * This function takes in the desired path in the bucket and the path
+ * to the local file and stores the file in the bucket.
+ * 
+ * @param destinationPath - The path that will be put in the bucket.
+ * @param localFilePath - The local file used to access the file.
+ */
+const uploadFileToFileSystem = async (destinationPath: string, localFilePath: string) => {
+  const options = {
+    destination: destinationPath,
+  }
+  await storage.bucket(bucketName).upload(localFilePath, options)
+}
+
+/**
+ * This function takes the desired folder path for the bucket and
+ * places it in the bucket. 
+ * 
+ * @param folderName - The desired path for the folder in the bucket.
+ */
+const addFolderToFileSystem = async (folderPath: string) => {
+  const bucket = storage.bucket(bucketName)
+  const folder = bucket.file(`${folderPath}`)
+  await folder.save('')
+}
+
+/**
+ * This generates a url that allows the server to access the private
+ * GCB for the next hour.
+ * 
+ * @param filePath - The path of the desired file in the bucekt..
+ */
+const generateV4ReadSignedUrl = async (fileName: string) => {
+  const options = {
+    version: 'v4' as const,
+    action: 'read' as const,
+    expires: new Date(Date.now() + 15 * 60 * 1000),
+  }
+
+  const [url] = await storage
+    .bucket(bucketName)
+    .file(fileName)
+    .getSignedUrl(options)
+
+  return url
+}
+
+const gcpBucketUtils = {
+  uploadFileToFileSystem,
+  addFolderToFileSystem,
+  generateV4ReadSignedUrl
+}
+
+export default gcpBucketUtils


### PR DESCRIPTION
This pull request sets up the models for both Assignments and Submissions in the Prisma schema, sets up initial routes for both including creation and file management, and updated the util functions that mess with the GCP bucket.

This Pull Request:
- Created the models for both Assignments and Submission in the Prisma schema
- Created three routes, a POST request for creating the assignment that subsequently created a submission instance for each student, a POST request for students uploading files in their submission, and a DELETE request for students deleting files in their submission
- Created various service functions that interact with Prisma's ORM to support validation and update data
- Moved all related GCP Bucket util functions to their own file and own directory as they will be reused a lot, and keeping them in file system directory did not make much sense anymore

Upcoming Changes: 
- POST request to submit assignment
- GET requests for viewing all student submisisons, and for a student to view the assignment
- Create the UI and the forms/modals to interact with the assignments/submissions