### PR TITLE
Socket and Notification Banner

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "axios": "^1.10.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2"
+    "react-router-dom": "^7.6.2",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/api/authApi.ts
+++ b/client/src/api/authApi.ts
@@ -20,6 +20,10 @@ type authResponse = {
   accountType: UserRole | null;
 }
 
+type logOutResponse = {
+  message: string
+}
+
 /**
  * This function takes in the data from the account creation form and 
  * passes the information into a POST request to create an account.
@@ -71,9 +75,34 @@ const signIntoAccount = async ({email, password}: logInParams): Promise<[boolean
   }
 }
 
+/**
+ * This function logs out the user by sending the accessToken and refreshToken
+ * to the server. The server will then revoke the clients access to both tokens
+ * by removing them from the cookies.
+ * 
+ * @returns A message that either states the user was logged out or
+ * an error message
+ */
+const logOutAccount = async () => {
+  try {
+    const response = await axiosClient.post<logOutResponse>(
+      '/api/auth/logout',
+      {},
+      { headers: { 'Content-Type': 'application/json' },
+        withCredentials: true 
+      }
+    )
+    const message = response.data.message
+    return message
+  } catch (error) {
+    console.error(error)
+  }
+}
+
 const authApi = {
   createAccount,
-  signIntoAccount
+  signIntoAccount,
+  logOutAccount
 }
 
 export default authApi

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBell, faFolderOpen, faBook, type IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { faBell, faRightFromBracket, faFolderOpen, faBook, type IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import useClassroom from '../hooks/useClassroom'
 import profilePic from '../assets/images/people-face-avatar-icon-cartoon-character-png.webp'
 import '../styles/sidebar.css'
 import '../styles/root.css'
 import { Link, useNavigate } from 'react-router-dom'
+import authApi from '../api/authApi'
+import useAuth from '../hooks/useAuth'
 
 interface navOptions {
   [key: string]: [IconDefinition, string];
@@ -14,7 +16,8 @@ interface navOptions {
 const Sidebar = () => {
   const [baseUrl, setBaseUrl] = useState<string>('')
   const [isHovered, setIsHovered] = useState(false)
-  const { isClassroom, setCurrFileItem } = useClassroom()
+  const { setUserId, setAccountType } = useAuth()
+  const { isClassroom, setCurrFileItem, setIsClassroom, setCurrClass } = useClassroom()
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -31,6 +34,22 @@ const Sidebar = () => {
 
   const handleLinkClick = (key: string) => {
     key === "File System" && setCurrFileItem(null)
+  }
+
+  /**
+   * Makes the api call to logout the user, then clears all the states from both
+   * AuthContext and ClassroomContext.
+   */
+  const handleLogOut = async () => {
+    const logoutMessage = await authApi.logOutAccount()
+    if (logoutMessage) {
+      setUserId('')
+      setIsClassroom(false)
+      setCurrClass(null)
+      setCurrFileItem(null)
+      setAccountType(null)
+      navigate('/login')
+    }
   }
 
   return (
@@ -76,6 +95,12 @@ const Sidebar = () => {
             </div>
           </Link>
         )) : []}
+        <div onClick={handleLogOut} style={{borderTop: '1px solid var(--textColor)'}} className='sidebar-nav-container'>
+          <div className='sidebar-nav-content'>
+            <FontAwesomeIcon style={{transform: 'scale(1.25)'}} icon={faRightFromBracket} />
+            <span className={`sidebar-nav-content-text${isHovered ? ' hovered' : ''}`}>Log out</span>
+          </div>
+        </div>
     </div>
   )
 }

--- a/client/src/components/assignments/StudentAssignments.tsx
+++ b/client/src/components/assignments/StudentAssignments.tsx
@@ -21,7 +21,6 @@ const StudentAssignments = ({assignments}: studentAssignmentsProps) => {
     setSubmittedAssignments([])
     setOverdueAssignments([])
     for (const assignment of assignments) {
-      console.log(assignment)
       if (assignment.submissions[0].submitted === true) {
         setSubmittedAssignments(prev => [...prev, assignment])
       } else if (new Date(assignment.dueDate) < new Date()) {

--- a/client/src/components/notifications/NotificationBanner.tsx
+++ b/client/src/components/notifications/NotificationBanner.tsx
@@ -1,0 +1,26 @@
+import { useEffect } from "react"
+
+interface notificationBannerProps {
+  notificationClassName: string,
+  notificationType: any,
+  notificationMessage: any,
+  className?: string
+}
+
+const NotificationBanner = ({
+  notificationClassName, 
+  notificationType, 
+  notificationMessage, 
+  className
+}: notificationBannerProps) => {
+
+  return (
+    <div className={className}>
+      <h3 className="notification-banner-message">{notificationMessage}</h3>
+      <h3 className="notification-banner-info">{notificationClassName}</h3>
+      <h4 className="notification-banner-info">{notificationType}</h4>
+    </div>
+  )
+}
+
+export default NotificationBanner

--- a/client/src/components/notifications/NotificationBanner.tsx
+++ b/client/src/components/notifications/NotificationBanner.tsx
@@ -1,21 +1,30 @@
-import { useEffect } from "react"
+import { useNavigate } from "react-router-dom"
+import useAuth from "../../hooks/useAuth"
 
 interface notificationBannerProps {
   notificationClassName: string,
   notificationType: any,
   notificationMessage: any,
-  className?: string
+  className?: string,
+  classId: string
 }
 
 const NotificationBanner = ({
   notificationClassName, 
   notificationType, 
   notificationMessage, 
-  className
+  className,
+  classId
 }: notificationBannerProps) => {
+  const navigate = useNavigate()
+  const { userId } = useAuth()
+
+  const handleNotificationClick = () => {
+    navigate(`/${userId}/classrooms/${classId}/notifications`)
+  }
 
   return (
-    <div className={className}>
+    <div onClick={handleNotificationClick} className={className}>
       <h3 className="notification-banner-message">{notificationMessage}</h3>
       <h3 className="notification-banner-info">{notificationClassName}</h3>
       <h4 className="notification-banner-info">{notificationType}</h4>

--- a/client/src/context/AuthContext.tsx
+++ b/client/src/context/AuthContext.tsx
@@ -38,7 +38,6 @@ export const AuthProvider = ({children}: AuthContextChildren) => {
     } else {
       localStorage.removeItem('userId')
       if (socket) {
-        console.log('here')
         socket.disconnect()
         setSocket(null)
       }
@@ -60,7 +59,7 @@ export const AuthProvider = ({children}: AuthContextChildren) => {
     setAccountType,
     socket,
     setSocket
-  }), [userId, accountType])
+  }), [userId, accountType, socket])
 
   return (
     <AuthContext.Provider value={value}>

--- a/client/src/pages/ClassPage.tsx
+++ b/client/src/pages/ClassPage.tsx
@@ -3,11 +3,27 @@ import Sidebar from "../components/Sidebar"
 import { useEffect } from "react"
 import useClassroom from "../hooks/useClassroom"
 import '../styles/course.css'
+import useAuth from "../hooks/useAuth"
 
 const ClassPage = () => {
-
   const { setIsClassroom } = useClassroom()
-  useEffect(() => { setIsClassroom(true) }, [])
+  const { socket } = useAuth()
+
+  const handleNotificationReceived = (classId: any, notificationType: any, data: any) => {
+    
+  }
+
+  useEffect(() => {
+    setIsClassroom(true)
+  }, [])
+
+  useEffect(() => {
+    if (!socket) return
+    socket.on('notificationPosted', handleNotificationReceived)
+    return () => {
+      socket?.off('notificationPosted', handleNotificationReceived)
+    }
+  }, [socket])
 
   return (
     <div className="course-page">

--- a/client/src/pages/ClassPage.tsx
+++ b/client/src/pages/ClassPage.tsx
@@ -1,17 +1,21 @@
 import { Outlet } from "react-router-dom"
 import Sidebar from "../components/Sidebar"
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import useClassroom from "../hooks/useClassroom"
 import '../styles/course.css'
 import useAuth from "../hooks/useAuth"
+import notificationsUtils from "../utils/notificationsUtils"
+import classesApi from "../api/classesApi"
+import NotificationBanner from "../components/notifications/NotificationBanner"
+import '../styles/notifications.css'
 
 const ClassPage = () => {
+  const [notificationClassName, setNotificationClassName] = useState<string>('')
+  const [notificationType, setNotificationType] = useState<any>(null)
+  const [notificationMessage, setNotificationMessage] = useState<any>(null)
+  const [toggleBanner, setToggleBanner] = useState<boolean>(false)
   const { setIsClassroom } = useClassroom()
-  const { socket } = useAuth()
-
-  const handleNotificationReceived = (classId: any, notificationType: any, data: any) => {
-    
-  }
+  const { socket, userId } = useAuth()
 
   useEffect(() => {
     setIsClassroom(true)
@@ -19,6 +23,30 @@ const ClassPage = () => {
 
   useEffect(() => {
     if (!socket) return
+    const handleNotificationReceived = async (classId: any, notificationType: any, data: any) => {
+      console.log(data)
+      const formattedMessage = notificationsUtils.formatNotificationMessage(
+        data,
+        notificationType
+      )
+      console.log(formattedMessage)
+      const [classInfo, status, message] = await classesApi.getClassDetails(
+        userId,
+        classId
+      )
+      if (status) {
+        setNotificationClassName(classInfo.name)
+        setNotificationType(notificationType)
+        setNotificationMessage(formattedMessage)
+        setToggleBanner(true)
+        setTimeout(() => {
+          setNotificationClassName('')
+          setNotificationType(null)
+          setNotificationMessage(null)
+          setToggleBanner(false)
+        })
+      }
+    }
     socket.on('notificationPosted', handleNotificationReceived)
     return () => {
       socket?.off('notificationPosted', handleNotificationReceived)
@@ -27,6 +55,12 @@ const ClassPage = () => {
 
   return (
     <div className="course-page">
+      <NotificationBanner
+        className={`notification-banner ${toggleBanner ? 'visible' : ''}`} 
+        notificationClassName={notificationClassName}
+        notificationType={notificationType}
+        notificationMessage={notificationMessage}
+      />
       <Sidebar />
       <Outlet />
     </div>

--- a/client/src/pages/ClassPage.tsx
+++ b/client/src/pages/ClassPage.tsx
@@ -11,6 +11,7 @@ import '../styles/notifications.css'
 
 const ClassPage = () => {
   const [notificationClassName, setNotificationClassName] = useState<string>('')
+  const [notificationClassId, setNotificationClassId] = useState<string>('')
   const [notificationType, setNotificationType] = useState<any>(null)
   const [notificationMessage, setNotificationMessage] = useState<any>(null)
   const [toggleBanner, setToggleBanner] = useState<boolean>(false)
@@ -24,7 +25,6 @@ const ClassPage = () => {
   useEffect(() => {
     if (!socket) return
     const handleNotificationReceived = async (classId: any, notificationType: any, data: any) => {
-      console.log(data)
       const formattedMessage = notificationsUtils.formatNotificationMessage(
         data,
         notificationType
@@ -36,15 +36,17 @@ const ClassPage = () => {
       )
       if (status) {
         setNotificationClassName(classInfo.name)
+        setNotificationClassId(classId)
         setNotificationType(notificationType)
         setNotificationMessage(formattedMessage)
         setToggleBanner(true)
         setTimeout(() => {
           setNotificationClassName('')
+          setNotificationClassId('')
           setNotificationType(null)
           setNotificationMessage(null)
           setToggleBanner(false)
-        })
+        }, 5000)
       }
     }
     socket.on('notificationPosted', handleNotificationReceived)
@@ -60,6 +62,7 @@ const ClassPage = () => {
         notificationClassName={notificationClassName}
         notificationType={notificationType}
         notificationMessage={notificationMessage}
+        classId={notificationClassId}
       />
       <Sidebar />
       <Outlet />

--- a/client/src/pages/Classrooms.tsx
+++ b/client/src/pages/Classrooms.tsx
@@ -1,16 +1,62 @@
-import { useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import useClassroom from '../hooks/useClassroom'
 import Sidebar from '../components/Sidebar'
 import ClassroomsGrid from '../components/classes/ClassroomsGrid'
 import '../styles/classrooms.css'
+import useAuth from '../hooks/useAuth'
+import NotificationBanner from '../components/notifications/NotificationBanner'
+import { NotificationType } from '../utils/NotificationType'
+import classesApi from '../api/classesApi'
+import notificationsUtils from '../utils/notificationsUtils'
+import '../styles/notifications.css'
 
 const ClassroomsPage = () => {
-  
+  const [notificationClassName, setNotificationClassName] = useState<string>('')
+  const [notificationType, setNotificationType] = useState<any>(null)
+  const [notificationMessage, setNotificationMessage] = useState<any>(null)
+  const [toggleBanner, setToggleBanner] = useState<boolean>(false)
   const { setIsClassroom } = useClassroom()
+  const { socket, userId } = useAuth()
   useEffect(() => { setIsClassroom(false) }, [])
+
+  useEffect(() => {
+    if (!socket) return
+    const handleNotificationReceived = async (classId: any, notificationType: any, data: any) => {
+      const formattedMessage = notificationsUtils.formatNotificationMessage(
+        data,
+        notificationType
+      )
+      const [classInfo, status, message] = await classesApi.getClassDetails(
+        userId,
+        classId
+      )
+      if (status) {
+        setNotificationClassName(classInfo.name)
+        setNotificationType(notificationType)
+        setNotificationMessage(formattedMessage)
+        setToggleBanner(true)
+        setTimeout(() => {
+          setNotificationClassName('')
+          setNotificationType(null)
+          setNotificationMessage(null)
+          setToggleBanner(false)
+        }, 5000)
+      }
+    }
+    socket.on('notificationPosted', handleNotificationReceived)
+    return () => {
+      socket?.off('notificationPosted', handleNotificationReceived)
+    }
+  }, [socket])
 
   return (
     <div className='classroom-page'>
+      <NotificationBanner 
+        className={`notification-banner ${toggleBanner ? 'visible' : ''}`}
+        notificationClassName={notificationClassName}
+        notificationType={notificationType}
+        notificationMessage={notificationMessage}
+      />
       <Sidebar />
       <ClassroomsGrid />
     </div>

--- a/client/src/pages/Classrooms.tsx
+++ b/client/src/pages/Classrooms.tsx
@@ -1,17 +1,17 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import useClassroom from '../hooks/useClassroom'
 import Sidebar from '../components/Sidebar'
 import ClassroomsGrid from '../components/classes/ClassroomsGrid'
 import '../styles/classrooms.css'
 import useAuth from '../hooks/useAuth'
 import NotificationBanner from '../components/notifications/NotificationBanner'
-import { NotificationType } from '../utils/NotificationType'
 import classesApi from '../api/classesApi'
 import notificationsUtils from '../utils/notificationsUtils'
 import '../styles/notifications.css'
 
 const ClassroomsPage = () => {
   const [notificationClassName, setNotificationClassName] = useState<string>('')
+  const [notificationClassId, setNotificationClassId] = useState<string>('')
   const [notificationType, setNotificationType] = useState<any>(null)
   const [notificationMessage, setNotificationMessage] = useState<any>(null)
   const [toggleBanner, setToggleBanner] = useState<boolean>(false)
@@ -32,11 +32,13 @@ const ClassroomsPage = () => {
       )
       if (status) {
         setNotificationClassName(classInfo.name)
+        setNotificationClassId(classId)
         setNotificationType(notificationType)
         setNotificationMessage(formattedMessage)
         setToggleBanner(true)
         setTimeout(() => {
           setNotificationClassName('')
+          setNotificationClassId('')
           setNotificationType(null)
           setNotificationMessage(null)
           setToggleBanner(false)
@@ -56,6 +58,7 @@ const ClassroomsPage = () => {
         notificationClassName={notificationClassName}
         notificationType={notificationType}
         notificationMessage={notificationMessage}
+        classId={notificationClassId}
       />
       <Sidebar />
       <ClassroomsGrid />

--- a/client/src/styles/notifications.css
+++ b/client/src/styles/notifications.css
@@ -23,7 +23,7 @@
   border: 1px solid var(--textColor);
   border-radius: 20px;
   overflow: hidden;
-  transition: height 0.6s ease;
+  transition: max-height 0.6s ease;
 }
 
 .notification-widget:hover {

--- a/client/src/styles/notifications.css
+++ b/client/src/styles/notifications.css
@@ -60,3 +60,45 @@
 .notification-widget-item-text {
   font-size: 16px;
 }
+
+.notification-banner {
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+  /* Optional: keep the element in the layout during fade out */
+  pointer-events: none;
+}
+.notification-banner.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.notification-banner {
+  position: fixed;
+  top: 3.5vh;
+  right: 2vw;
+  height: 100px;
+  width: 300px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 8px 12px;
+  background-color: var(--componentColor);
+  border: 1px solid var(--textColor);
+  border-radius: 15px;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+  pointer-events: none;
+}
+
+.notification-banner.visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.notification-banner-message {
+  font-size: 22px;
+}
+
+.notification-banner-info {
+  font-size: 14px;
+}

--- a/client/src/styles/notifications.css
+++ b/client/src/styles/notifications.css
@@ -96,7 +96,7 @@
 }
 
 .notification-banner-message {
-  font-size: 22px;
+  font-size: 20px;
 }
 
 .notification-banner-info {

--- a/client/src/utils/notificationsUtils.ts
+++ b/client/src/utils/notificationsUtils.ts
@@ -103,6 +103,30 @@ const navigateToNotification = (
 }
 
 /**
+ * Formats the notification message to appear on the notification banner.
+ * 
+ * @param notificationData 
+ * @param notificationType 
+ * @returns 
+ */
+const formatNotificationMessage = (
+  notificationData: any,
+  notificationType: NotificationType,
+) => {
+  switch (notificationType) {
+    case NotificationType.AnnouncementPosted:
+      return `${notificationData.announcementTitle}`
+    case NotificationType.AssignmentPosted:
+      return `${notificationData.name} was assigned`
+    case NotificationType.FileSystemItemCreated:
+      return `${notificationData.name} was uploaded`
+    case NotificationType.StudentSubmission:
+      return `${notificationData.submissions[0].student.firstName} ${notificationData.submissions[0].student.lastName} 
+      submitted the following assignment: ${notificationData.name}`
+  }
+}
+
+/**
  * This function takes in all the notifications fetched and counts the number of 
  * unread  notifications and how many hours they have been unread for each of the 
  * different student categories.
@@ -214,6 +238,11 @@ const sortWidgetsByScore = (
     .map(({ widget }) => [widget.name, widget.type] as [string, NotificationType])
 }
 
+/**
+ * 
+ * @param notifications 
+ * @returns 
+ */
 const fetchedOrderStudentWidgets = (notifications: any) => {
   const notificationsData: Map<NotificationType, scoreArray> = sortStudentWidgets(notifications)
   const totalCounts = getTotalNotificationCounts(notifications)
@@ -227,7 +256,8 @@ const fetchedOrderStudentWidgets = (notifications: any) => {
 const notificationsUtils = {
   formatNotificationItem,
   navigateToNotification,
-  fetchedOrderStudentWidgets
+  fetchedOrderStudentWidgets,
+  formatNotificationMessage
 }
 
 export default notificationsUtils

--- a/client/src/utils/notificationsUtils.ts
+++ b/client/src/utils/notificationsUtils.ts
@@ -21,6 +21,10 @@ type scoreArray = {
   unreadHours: number
 }
 
+/**
+ * Alpha is the weight for the number of notifications unread, Beta is the number of
+ * hours the unread notifications have been unread.
+ */
 const alpha = 2
 const beta = 1
 
@@ -203,7 +207,7 @@ const sortWidgetsByScore = (
       if (aNoUnread && bNoUnread) {
         const aTotal = totalCounts.get(a.widget.type) || 0
         const bTotal = totalCounts.get(b.widget.type) || 0
-        return bTotal - aTotal;
+        return bTotal - aTotal
       }
       return b.score - a.score
     })

--- a/client/src/utils/notificationsUtils.ts
+++ b/client/src/utils/notificationsUtils.ts
@@ -105,9 +105,10 @@ const navigateToNotification = (
 /**
  * Formats the notification message to appear on the notification banner.
  * 
- * @param notificationData 
- * @param notificationType 
- * @returns 
+ * @param notificationData - The data needed for the correct message to be displayed.
+ * @param notificationType - The notification category that is used in this function's
+ * switch case.
+ * @returns The new message to be displayed in the banner.
  */
 const formatNotificationMessage = (
   notificationData: any,
@@ -239,9 +240,12 @@ const sortWidgetsByScore = (
 }
 
 /**
+ * This function takes in the notifications to be sorted for the student and runs 
+ * functions to get the notification data to sort and then sorts the notification 
+ * categories.
  * 
- * @param notifications 
- * @returns 
+ * @param notifications - The notifications that decide the category sorting.
+ * @returns The widget name and type in a sorted list.
  */
 const fetchedOrderStudentWidgets = (notifications: any) => {
   const notificationsData: Map<NotificationType, scoreArray> = sortStudentWidgets(notifications)

--- a/server/package.json
+++ b/server/package.json
@@ -16,13 +16,17 @@
     "@google-cloud/storage": "^7.16.0",
     "@prisma/client": "^6.10.1",
     "@types/dotenv": "^6.1.1",
+    "@types/socket.io": "^3.0.1",
+    "@types/socket.io-client": "^1.4.36",
     "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "multer": "^2.0.1"
+    "multer": "^2.0.1",
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",
@@ -32,7 +36,7 @@
     "@types/jest": "^30.0.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^2.0.0",
-    "@types/node": "^24.0.3",
+    "@types/node": "^24.0.13",
     "jest": "^30.0.3",
     "jest-mock-extended": "^4.0.0",
     "prisma": "^6.10.1",

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -21,6 +21,7 @@ model User {
   password               String
   accountType            UserRole
   refreshTokens          RefreshToken[]
+  socketId               String?
   createdAt              DateTime        @default(now())
   updatedAt              DateTime        @updatedAt
   studentClasses         Classes[]       @relation("studentClasses")

--- a/server/src/auth/auth.routes.ts
+++ b/server/src/auth/auth.routes.ts
@@ -3,6 +3,7 @@ import * as bcrypt from 'bcrypt'
 import authJwt from './auth.jwt'
 import authServices from './auth.services'
 import { prisma } from '../context/context'
+import io from '../sockets/index'
 
 const router = express.Router()
 const ctx = { prisma }

--- a/server/src/auth/auth.routes.ts
+++ b/server/src/auth/auth.routes.ts
@@ -164,4 +164,26 @@ router.post('/revokeRefreshToken', async (req, res, next) => {
   res.status(200).json({message: `Token revoked for User with Id ${userId}`})
 })
 
+/**
+ * This POST route logs out the user by clearing both the accessToken and the
+ * refreshToken from the client side.
+ */
+router.post('/logout', async (req, res, next) => {
+  res.clearCookie('refreshToken', {
+    'httpOnly': true,
+    'secure': true,
+    'sameSite': 'none',
+    'path': '/'
+  })
+
+  res.clearCookie('accessToken', {
+    'httpOnly': true,
+    'secure': true,
+    'sameSite': 'none',
+    'path': '/'
+  })
+
+  res.status(200).json({message: "User successfully logged out"})
+})
+
 export default router

--- a/server/src/auth/auth.services.ts
+++ b/server/src/auth/auth.services.ts
@@ -139,6 +139,51 @@ const revokeTokens = async (userId: string, ctx: Context) => {
   })
 }
 
+/**
+ * This function populates the empty socketId field for the specified
+ * user that connected to the socket io server.
+ * 
+ * @param userId - The id of the user connected.
+ * @param socketId - The socked id of the user connection.
+ * @param ctx - The prisma context that this function is being used in.
+ */
+const addSocketIdToUser = async (
+  userId: string,
+  socketId: string,
+  ctx: Context
+) => {
+  await ctx.prisma.user.update({
+    where: {
+      id: userId
+    },
+    data: {
+      socketId: socketId
+    }
+  })
+}
+
+/**
+ * This functions queries the user using the user id provided and removes
+ * the socket id previously stored as the user is now disconnected.
+ * 
+ * @param userId - The id of the user disconnecting from the socket io
+ * server.
+ * @param ctx - The prisma context that this function is being used in.
+ */
+const removeSocketIdFromUser = async (
+  userId: string,
+  ctx: Context
+) => {
+  await ctx.prisma.user.update({
+    where: {
+      id: userId
+    },
+    data: {
+      socketId: null
+    }
+  })
+}
+
 const authServices = {
   findUserByEmail,
   findUserById,
@@ -147,6 +192,8 @@ const authServices = {
   findRefreshToken,
   deleteRefreshTokenById,
   revokeTokens,
+  addSocketIdToUser,
+  removeSocketIdFromUser
 }
 
 export default authServices

--- a/server/src/notifications/notifications.utils.ts
+++ b/server/src/notifications/notifications.utils.ts
@@ -3,6 +3,7 @@ import { prisma } from "../context/context"
 import classService from "../classes/classes.services"
 import notificationServices from "./notifications.services"
 import { Response } from "express"
+import socketNotifications from "../sockets/socket.notifications"
 
 const ctx = { prisma }
 
@@ -49,6 +50,12 @@ const createNotificationAsStudent = async (
       [user.professor],
       ctx
     )
+    socketNotifications.sendNotificationToReceivers(
+      classId,
+      notificationType,
+      data,
+      [user.professor]
+    )
   } catch (error) {
     console.error(error)
   }
@@ -92,6 +99,12 @@ const createNotificationAsProfessor = async (
       data,
       users.students,
       ctx
+    )
+    socketNotifications.sendNotificationToReceivers(
+      classId,
+      notificationType,
+      data,
+      users.students
     )
   } catch (error) {
     console.error(error)

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,7 +1,25 @@
-import app from "./app"
+import app from './app'
+import http from 'http'
+import setUpSocketServer from './sockets'
+import { Server as SocketIOServer } from 'socket.io'
 
-const PORT = process.env.PORT || 3000
+const startServer = async () => {
+  const server = http.createServer(app)
+  const io = new SocketIOServer(server, {
+    cors: {
+      origin: 'http://localhost:5173',
+      credentials: true,
+    }
+  })
 
-app.listen(PORT, () => {
-  console.log(`Server is running on http://localhost:${PORT}`)
+  setUpSocketServer(io)
+
+  const PORT = process.env.PORT || 3000
+  server.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`)
+  })
+}
+
+startServer().catch((err) => {
+  console.error('Error starting the server', err)
 })

--- a/server/src/sockets/index.ts
+++ b/server/src/sockets/index.ts
@@ -1,0 +1,21 @@
+import { Server as SocketIOServer, Socket } from "socket.io"
+
+/**
+ * This function sets up the socket io server and creates all the events
+ * it is listening for.
+ * 
+ * @param io - The socket io server instance created in the server
+ */
+const setUpSocketServer = async (io: SocketIOServer): Promise<void> => {
+  io.disconnectSockets()
+
+  io.on('connection', (socket) => {
+    console.log('A user connected')
+    
+    socket.on('disconnect', () => {
+      console.log('User disconnected')
+    })
+  })
+}
+
+export default setUpSocketServer

--- a/server/src/sockets/index.ts
+++ b/server/src/sockets/index.ts
@@ -1,12 +1,14 @@
 import { Server as SocketIOServer, Socket } from "socket.io"
+import socketUtils from "./socket"
 
 /**
- * This function sets up the socket io server and creates all the events
- * it is listening for.
+ * This function sets up the socket io server and logs when a user
+ * connects and disconnects.
  * 
  * @param io - The socket io server instance created in the server
  */
 const setUpSocketServer = async (io: SocketIOServer): Promise<void> => {
+  socketUtils.initializeSocket(io)
   io.disconnectSockets()
 
   io.on('connection', (socket) => {

--- a/server/src/sockets/socket.notifications.ts
+++ b/server/src/sockets/socket.notifications.ts
@@ -1,0 +1,34 @@
+import { NotificationType } from "@prisma/client"
+import socketUtils from "./socket"
+
+/**
+ * This function loops through all receivers and emits the socket
+ * call with all the necessary information.
+ * 
+ * @param classId - The class the notification belongs to.
+ * @param notificationType - The category of the notification.
+ * @param data - All the dat from the notification.
+ * @param receivers - Used to find the socket.id of the receivers.
+ */
+const sendNotificationToReceivers = async (
+  classId: string,
+  notificationType: NotificationType,
+  data: any,
+  receivers: any[]
+) => {
+  const io = socketUtils.fetchIO()
+  for (const receiver of receivers) {
+    if (io && receiver.socketId) {
+      io.to(receiver.socketId).emit('notificationPosted',
+        classId,
+        notificationType,
+        data
+    )}
+  }
+}
+
+const socketNotifications = {
+  sendNotificationToReceivers
+}
+
+export default socketNotifications

--- a/server/src/sockets/socket.ts
+++ b/server/src/sockets/socket.ts
@@ -1,0 +1,31 @@
+import { Server as SocketIOServer } from "socket.io"
+let io: SocketIOServer | null = null
+
+/**
+ * This function instantiates the singleton instance of the IO server
+ * to be used in anywhere in the server.
+ * 
+ * @param ioInstance - The IO instance initialized that will be
+ * used to set the singleton.
+ */
+const initializeSocket = (ioInstance: SocketIOServer) => {
+  io = ioInstance
+}
+
+/**
+ * The function fetches the IO singleton initialized, logs an error
+ * message if failed to return the instance.
+ * 
+ * @returns The singleton io to be used anywhere in the server
+ */
+const fetchIO = () => {
+  if (!io) { console.error("IO instance does not exist") }
+  return io
+}
+
+const socketUtils = {
+  initializeSocket,
+  fetchIO
+}
+
+export default socketUtils


### PR DESCRIPTION
This pull request sets up the socket IO server in the backend, integrating it with anything that causes a notification, and then sets up the socket connection on the frontend to receive the notification live and allow you to navigate to it. Additionally, this also adds the log out feature to the sidebar.

This Pull Request: 
- Creates the Socket IO instance in the server.
- Added a log out route to the server which clears the tokens from the http safe cookies and a log out button to the sidebar to make that call and bring the user to the login screen.
- Added socket id to the user model, stored when the socket connection is established, passes the user id on connection and connects both ids.
- Creates the socket instance inside of useAuth context, stores the socket object inside a global state variable.
- Server emits a message to all users from the notification's receiver list with the data needed for the notification banner.
- On receive, the client connection displays a new notification banner component for five seconds. Clicking said component brings you to the notification page.

Upcoming Changes:
- Creates the server set up for the chatting and the chat bot.
- Design the layout of the chatting page, and research how to connect previous routes to chat bot.