### PR TITLE
Chat Interface Layout

### DIFF
--- a/client/src/Routes.tsx
+++ b/client/src/Routes.tsx
@@ -9,6 +9,7 @@ import ClassPage from './pages/ClassPage'
 import StudentSubmission from './components/submissions/StudentSubmission'
 import SubmissionList from './components/submissions/SubmissionList'
 import NotificationsWidgetMenu from './components/notifications/NotificationsWidgetMenu'
+import ChattingContainer from './components/chatting/ChattingContainer'
 
 const AppRoutes = () => (
   <Routes>
@@ -35,6 +36,7 @@ const AppRoutes = () => (
       <Route path='assignments/:assignmentId/submissions' element={<SubmissionList />}/>
       <Route path='assignments/:assignmentId' element={<StudentSubmission />} />
       <Route path='notifications' element={<NotificationsWidgetMenu />} />
+      <Route path='chatting' element={<ChattingContainer />} />
     </Route>
   </Routes>
 )

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBell, faRightFromBracket, faFolderOpen, faBook, type IconDefinition } from '@fortawesome/free-solid-svg-icons'
+import { faBell, faComment, faRightFromBracket, faFolderOpen, faBook, type IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import useClassroom from '../hooks/useClassroom'
 import profilePic from '../assets/images/people-face-avatar-icon-cartoon-character-png.webp'
 import '../styles/sidebar.css'
@@ -30,6 +30,7 @@ const Sidebar = () => {
     "Notifications": [faBell, "notifications"],
     "File System": [faFolderOpen, "files"],
     "Assignments": [faBook, "assignments"],
+    "Chatting": [faComment, "chatting"]
   }
 
   const handleLinkClick = (key: string) => {

--- a/client/src/components/chatting/ChattingContainer.tsx
+++ b/client/src/components/chatting/ChattingContainer.tsx
@@ -17,18 +17,14 @@ const ChattingContainer = () => {
     if (file) { setFile(file) }
   }
 
-  const handleKeyPress = (keyPressed: string) => {
-    if (
-      keyPressed === "Backspace" && 
-      chatInput.length === 0 &&
-      command.length > 0
-    ) { setCommand('') }
-  }
-
   useEffect(() => {
     if (chatInput.startsWith('@') && command.length === 0) { setToggleCommandHelper(true) }
-    else { setToggleCommandHelper(false) }
+    else if (command.length === 0) { setToggleCommandHelper(false) }
   }, [chatInput])
+
+  const handleKeyClick = (lastKey: string) => {
+    if (lastKey === "Backspace" && chatInput.length === 0) { setCommand(''); setToggleCommandHelper(false)}
+  }
 
   return (
     <div className="chatting-page">
@@ -36,7 +32,8 @@ const ChattingContainer = () => {
         <h1>{currClass.className} | Class Chat</h1>
       </div>
       <div className='chatbox-container'>
-        <CommandHelper 
+        <CommandHelper
+          command={command} 
           setCommand={setCommand}
           setToggleCommandHelper={setToggleCommandHelper}
           setChatInput={setChatInput}
@@ -47,7 +44,7 @@ const ChattingContainer = () => {
           <input 
             value={chatInput} 
             onChange={(event) => setChatInput(event.target.value)}
-            onKeyDown={(event) => handleKeyPress(event.key)}
+            onKeyDown={(event) => handleKeyClick(event.key)}
           />
           <div style={{display: 'flex'}}>
             <label htmlFor="chat-file-upload" style={{ cursor: 'pointer' }}>

--- a/client/src/components/chatting/ChattingContainer.tsx
+++ b/client/src/components/chatting/ChattingContainer.tsx
@@ -2,11 +2,13 @@ import useClassroom from '../../hooks/useClassroom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faImage } from '@fortawesome/free-solid-svg-icons'
 import '../../styles/chatting.css'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import CommandHelper from './CommandHelper'
 
 const ChattingContainer = () => {
   const [chatInput, setChatInput] = useState<string>('')
   const [file, setFile] = useState<null | File>(null)
+  const [toggleCommandHelper, setToggleCommandHelper] = useState<boolean>(false)
   const { currClass } = useClassroom()
 
   const handleFileChange = (event: any) => {
@@ -14,12 +16,18 @@ const ChattingContainer = () => {
     if (file) { setFile(file) }
   }
 
+  useEffect(() => {
+    if (chatInput.startsWith('@')) { setToggleCommandHelper(true) }
+    else { setToggleCommandHelper(false) }
+  }, [chatInput])
+
   return (
     <div className="chatting-page">
       <div className='chatting-header'>
         <h1>{currClass.className} | Class Chat</h1>
       </div>
       <div className='chatbox-container'>
+        <CommandHelper className={`command-helper-container ${toggleCommandHelper ? 'visible' : ''}`}/>
         <div className='input-container'>
           <input value={chatInput} onChange={(event) => setChatInput(event.target.value)}/>
           <div style={{display: 'flex'}}>

--- a/client/src/components/chatting/ChattingContainer.tsx
+++ b/client/src/components/chatting/ChattingContainer.tsx
@@ -1,0 +1,18 @@
+import useClassroom from '../../hooks/useClassroom'
+import '../../styles/chatting.css'
+
+const ChattingContainer = () => {
+  const { currClass } = useClassroom()
+  return (
+    <div className="chatting-page">
+      <div className='chatting-header'>
+        <h1>{currClass.className} | Class Chat</h1>
+      </div>
+      <div className='chatbox-container'>
+        
+      </div>
+    </div>
+  )
+}
+
+export default ChattingContainer

--- a/client/src/components/chatting/ChattingContainer.tsx
+++ b/client/src/components/chatting/ChattingContainer.tsx
@@ -1,6 +1,6 @@
 import useClassroom from '../../hooks/useClassroom'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faImage } from '@fortawesome/free-solid-svg-icons'
+import { faImage, faPaperPlane } from '@fortawesome/free-solid-svg-icons'
 import '../../styles/chatting.css'
 import { useEffect, useState } from 'react'
 import CommandHelper from './CommandHelper'
@@ -39,18 +39,23 @@ const ChattingContainer = () => {
           setChatInput={setChatInput}
           className={`command-helper-container ${toggleCommandHelper ? 'visible' : ''}`}
         />
-        <div className='input-container'>
-          {command.length > 0 && <span style={{opacity: '40%', marginRight: '5px'}}>{command}:</span>}
-          <input 
-            value={chatInput} 
-            onChange={(event) => setChatInput(event.target.value)}
-            onKeyDown={(event) => handleKeyClick(event.key)}
-          />
-          <div style={{display: 'flex'}}>
-            <label htmlFor="chat-file-upload" style={{ cursor: 'pointer' }}>
-              <FontAwesomeIcon icon={faImage} />
-            </label>
-            <input onChange={(event) => handleFileChange(event)} id='chat-file-upload' type='file' style={{ display: 'none' }}/>
+        <div className='input-and-send-container'>
+          <div className='input-container'>
+            {command.length > 0 && <span style={{opacity: '40%', marginRight: '5px'}}>{command}:</span>}
+            <input 
+              value={chatInput} 
+              onChange={(event) => setChatInput(event.target.value)}
+              onKeyDown={(event) => handleKeyClick(event.key)}
+            />
+            <div style={{display: 'flex'}}>
+              <label htmlFor="chat-file-upload" style={{ cursor: 'pointer' }}>
+                <FontAwesomeIcon icon={faImage} />
+              </label>
+              <input onChange={(event) => handleFileChange(event)} id='chat-file-upload' type='file' style={{ display: 'none' }}/>
+            </div>
+          </div>
+          <div className='send-btn-container' style={chatInput.length > 0 ? {backgroundColor: 'var(--button)'} : {backgroundColor: 'var(--componentColor'}}>
+            <FontAwesomeIcon icon={faPaperPlane}/>
           </div>
         </div>
       </div>

--- a/client/src/components/chatting/ChattingContainer.tsx
+++ b/client/src/components/chatting/ChattingContainer.tsx
@@ -32,30 +32,32 @@ const ChattingContainer = () => {
         <h1>{currClass.className} | Class Chat</h1>
       </div>
       <div className='chatbox-container'>
-        <CommandHelper
-          command={command} 
-          setCommand={setCommand}
-          setToggleCommandHelper={setToggleCommandHelper}
-          setChatInput={setChatInput}
-          className={`command-helper-container ${toggleCommandHelper ? 'visible' : ''}`}
-        />
-        <div className='input-and-send-container'>
-          <div className='input-container'>
-            {command.length > 0 && <span style={{opacity: '40%', marginRight: '5px'}}>{command}:</span>}
-            <input 
-              value={chatInput} 
-              onChange={(event) => setChatInput(event.target.value)}
-              onKeyDown={(event) => handleKeyClick(event.key)}
-            />
-            <div style={{display: 'flex'}}>
-              <label htmlFor="chat-file-upload" style={{ cursor: 'pointer' }}>
-                <FontAwesomeIcon icon={faImage} />
-              </label>
-              <input onChange={(event) => handleFileChange(event)} id='chat-file-upload' type='file' style={{ display: 'none' }}/>
+        <div className='chatbox-interactive-container'>
+          <CommandHelper
+            command={command}
+            setCommand={setCommand}
+            setToggleCommandHelper={setToggleCommandHelper}
+            setChatInput={setChatInput}
+            className={`command-helper-container ${toggleCommandHelper ? 'visible' : ''}`}
+          />
+          <div className='input-and-send-container'>
+            <div className='input-container'>
+              {command.length > 0 && <span style={{opacity: '40%', marginRight: '5px'}}>{command}:</span>}
+              <input 
+                value={chatInput} 
+                onChange={(event) => setChatInput(event.target.value)}
+                onKeyDown={(event) => handleKeyClick(event.key)}
+              />
+              <div style={{display: 'flex'}}>
+                <label htmlFor="chat-file-upload" style={{ cursor: 'pointer' }}>
+                  <FontAwesomeIcon icon={faImage} />
+                </label>
+                <input onChange={(event) => handleFileChange(event)} id='chat-file-upload' type='file' style={{ display: 'none' }}/>
+              </div>
             </div>
-          </div>
-          <div className='send-btn-container' style={chatInput.length > 0 ? {backgroundColor: 'var(--button)'} : {backgroundColor: 'var(--componentColor'}}>
-            <FontAwesomeIcon icon={faPaperPlane}/>
+            <div className='send-btn-container' style={chatInput.length > 0 ? {backgroundColor: 'var(--button)'} : {backgroundColor: 'var(--componentColor'}}>
+              <FontAwesomeIcon icon={faPaperPlane}/>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/components/chatting/ChattingContainer.tsx
+++ b/client/src/components/chatting/ChattingContainer.tsx
@@ -7,6 +7,7 @@ import CommandHelper from './CommandHelper'
 
 const ChattingContainer = () => {
   const [chatInput, setChatInput] = useState<string>('')
+  const [command, setCommand] = useState<string>('')
   const [file, setFile] = useState<null | File>(null)
   const [toggleCommandHelper, setToggleCommandHelper] = useState<boolean>(false)
   const { currClass } = useClassroom()
@@ -16,8 +17,16 @@ const ChattingContainer = () => {
     if (file) { setFile(file) }
   }
 
+  const handleKeyPress = (keyPressed: string) => {
+    if (
+      keyPressed === "Backspace" && 
+      chatInput.length === 0 &&
+      command.length > 0
+    ) { setCommand('') }
+  }
+
   useEffect(() => {
-    if (chatInput.startsWith('@')) { setToggleCommandHelper(true) }
+    if (chatInput.startsWith('@') && command.length === 0) { setToggleCommandHelper(true) }
     else { setToggleCommandHelper(false) }
   }, [chatInput])
 
@@ -27,9 +36,19 @@ const ChattingContainer = () => {
         <h1>{currClass.className} | Class Chat</h1>
       </div>
       <div className='chatbox-container'>
-        <CommandHelper className={`command-helper-container ${toggleCommandHelper ? 'visible' : ''}`}/>
+        <CommandHelper 
+          setCommand={setCommand}
+          setToggleCommandHelper={setToggleCommandHelper}
+          setChatInput={setChatInput}
+          className={`command-helper-container ${toggleCommandHelper ? 'visible' : ''}`}
+        />
         <div className='input-container'>
-          <input value={chatInput} onChange={(event) => setChatInput(event.target.value)}/>
+          {command.length > 0 && <span style={{opacity: '40%', marginRight: '5px'}}>{command}:</span>}
+          <input 
+            value={chatInput} 
+            onChange={(event) => setChatInput(event.target.value)}
+            onKeyDown={(event) => handleKeyPress(event.key)}
+          />
           <div style={{display: 'flex'}}>
             <label htmlFor="chat-file-upload" style={{ cursor: 'pointer' }}>
               <FontAwesomeIcon icon={faImage} />

--- a/client/src/components/chatting/ChattingContainer.tsx
+++ b/client/src/components/chatting/ChattingContainer.tsx
@@ -1,15 +1,34 @@
 import useClassroom from '../../hooks/useClassroom'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faImage } from '@fortawesome/free-solid-svg-icons'
 import '../../styles/chatting.css'
+import { useState } from 'react'
 
 const ChattingContainer = () => {
+  const [chatInput, setChatInput] = useState<string>('')
+  const [file, setFile] = useState<null | File>(null)
   const { currClass } = useClassroom()
+
+  const handleFileChange = (event: any) => {
+    const file = event.target.files?.[0]
+    if (file) { setFile(file) }
+  }
+
   return (
     <div className="chatting-page">
       <div className='chatting-header'>
         <h1>{currClass.className} | Class Chat</h1>
       </div>
       <div className='chatbox-container'>
-        
+        <div className='input-container'>
+          <input value={chatInput} onChange={(event) => setChatInput(event.target.value)}/>
+          <div style={{display: 'flex'}}>
+            <label htmlFor="chat-file-upload" style={{ cursor: 'pointer' }}>
+              <FontAwesomeIcon icon={faImage} />
+            </label>
+            <input onChange={(event) => handleFileChange(event)} id='chat-file-upload' type='file' style={{ display: 'none' }}/>
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/client/src/components/chatting/CommandHelper.tsx
+++ b/client/src/components/chatting/CommandHelper.tsx
@@ -4,6 +4,7 @@ import '../../styles/chatting.css'
 import type { ReactFormState } from 'react-dom/client'
 
 interface commandHelperProps {
+  command: string;
   className: string;
   setToggleCommandHelper: React.Dispatch<React.SetStateAction<boolean>>;
   setCommand: React.Dispatch<React.SetStateAction<string>>;
@@ -11,6 +12,7 @@ interface commandHelperProps {
 }
 
 const CommandHelper = ({
+  command,
   className,
   setCommand,
   setToggleCommandHelper,
@@ -19,15 +21,16 @@ const CommandHelper = ({
 
   const commands = [["commandBot", faRobot], ["ping", faBell]]
 
+  const commandBotGuideLines = [["params:", "type inside single quotations"], ["accessible features:", "assignments, submisisons, announcements, filesystem"]]
+
   const handleItemClick = (item: [string, IconDefinition]) => {
     setCommand(item[0])
-    setToggleCommandHelper(false)
     setChatInput('')
   }
 
   return (
     <div className={className}>
-      {commands.map((item: any, key: any) => (
+      {command.length === 0 ? commands.map((item: any, key: any) => (
         <div 
           onClick={() => handleItemClick(item)}
           className='command-helper-item' key={key}
@@ -37,7 +40,16 @@ const CommandHelper = ({
             </div>
             <span>{item[0]}</span>
         </div>
-      ))}
+      )) : command === "commandBot" ? (
+        <>
+          {commandBotGuideLines.map((guideline: any, key: any) => (
+            <div className='command-helper-guideline-item'>
+              <span>{guideline[0]}</span>
+              <span style={{opacity: '40%'}}>{guideline[1]}</span>
+            </div>
+          ))}
+        </>
+      ) : []}
     </div>
   )
 }

--- a/client/src/components/chatting/CommandHelper.tsx
+++ b/client/src/components/chatting/CommandHelper.tsx
@@ -1,0 +1,31 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faRobot, faBell } from '@fortawesome/free-solid-svg-icons'
+import '../../styles/chatting.css'
+
+interface commandHelperProps {
+  className: string
+}
+
+const CommandHelper = ({className}: commandHelperProps) => {
+
+  const commands = [["commandBot", faRobot], ["ping", faBell]]
+
+  const handleCommandClick = () => {
+    
+  }
+
+  return (
+    <div className={className}>
+      {commands.map((item: any, key: any) => (
+        <div onClick={handleCommandClick} className='command-helper-item' key={key}>
+            <div className='command-helper-item-icon'>
+              <FontAwesomeIcon icon={item[1]} />
+            </div>
+            <span>{item[0]}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default CommandHelper

--- a/client/src/components/chatting/CommandHelper.tsx
+++ b/client/src/components/chatting/CommandHelper.tsx
@@ -21,7 +21,7 @@ const CommandHelper = ({
 
   const commands = [["commandBot", faRobot], ["ping", faBell]]
 
-  const commandBotGuideLines = [["params:", "type inside single quotations"], ["accessible features:", "assignments, submisisons, announcements, filesystem"]]
+  const commandBotGuideLines = [["params:", "type inside single quotations"], ["accessible features:", "assignment, submisison, announcement, filesystem"]]
 
   const handleItemClick = (item: [string, IconDefinition]) => {
     setCommand(item[0])

--- a/client/src/components/chatting/CommandHelper.tsx
+++ b/client/src/components/chatting/CommandHelper.tsx
@@ -1,23 +1,37 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faRobot, faBell } from '@fortawesome/free-solid-svg-icons'
+import { faRobot, faBell, type IconDefinition } from '@fortawesome/free-solid-svg-icons'
 import '../../styles/chatting.css'
+import type { ReactFormState } from 'react-dom/client'
 
 interface commandHelperProps {
-  className: string
+  className: string;
+  setToggleCommandHelper: React.Dispatch<React.SetStateAction<boolean>>;
+  setCommand: React.Dispatch<React.SetStateAction<string>>;
+  setChatInput: React.Dispatch<React.SetStateAction<string>>;
 }
 
-const CommandHelper = ({className}: commandHelperProps) => {
+const CommandHelper = ({
+  className,
+  setCommand,
+  setToggleCommandHelper,
+  setChatInput
+}: commandHelperProps) => {
 
   const commands = [["commandBot", faRobot], ["ping", faBell]]
 
-  const handleCommandClick = () => {
-    
+  const handleItemClick = (item: [string, IconDefinition]) => {
+    setCommand(item[0])
+    setToggleCommandHelper(false)
+    setChatInput('')
   }
 
   return (
     <div className={className}>
       {commands.map((item: any, key: any) => (
-        <div onClick={handleCommandClick} className='command-helper-item' key={key}>
+        <div 
+          onClick={() => handleItemClick(item)}
+          className='command-helper-item' key={key}
+        >
             <div className='command-helper-item-icon'>
               <FontAwesomeIcon icon={item[1]} />
             </div>

--- a/client/src/pages/ClassPage.tsx
+++ b/client/src/pages/ClassPage.tsx
@@ -29,7 +29,6 @@ const ClassPage = () => {
         data,
         notificationType
       )
-      console.log(formattedMessage)
       const [classInfo, status, message] = await classesApi.getClassDetails(
         userId,
         classId

--- a/client/src/styles/chatting.css
+++ b/client/src/styles/chatting.css
@@ -25,13 +25,13 @@
 }
 
 .input-container {
-  height: 35px;
+  height: 45px;
   width: 100%;
   padding: 0 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-radius: 12px;
+  border-radius: 10px;
   background-color: var(--componentColor);
 }
 
@@ -41,4 +41,46 @@
   color: inherit;
   box-sizing: border-box;
   width: 100%;
+}
+
+.command-helper-container {
+  width: 100%;
+  background-color: #343E53;
+  transform: translateY(50px);
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+  opacity: 0;
+  transition: opacity 0.2s ease-out, transform 0.2s ease-in;
+  pointer-events: none;
+}
+
+.command-helper-container.visible {
+  opacity: 1;
+  transform: translateY(7px);
+  transition: opacity 0.6s ease-in-out, transform 0.3s ease-in;
+  pointer-events: auto;
+}
+
+.command-helper-container.visible > div:first-child {
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
+}
+
+.command-helper-item {
+  padding: 20px 0px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  cursor: pointer;
+}
+
+.command-helper-item:hover {
+  background-color: #434B5B;
+}
+
+.command-helper-item-icon {
+  width: 58px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }

--- a/client/src/styles/chatting.css
+++ b/client/src/styles/chatting.css
@@ -24,12 +24,18 @@
   align-items: center;
 }
 
+.chatbox-interactive-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  position: relative;
+}
+
 .input-and-send-container {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
-  gap: 20px;
   width: 100%;
 }
 
@@ -41,7 +47,7 @@
 
 .input-container {
   height: 45px;
-  width: 100%;
+  width: 95%;
   padding: 0 20px;
   display: flex;
   justify-content: space-between;
@@ -59,9 +65,11 @@
 }
 
 .command-helper-container {
-  width: 90%;
+  position: absolute;
+  z-index: 2;
+  width: 95%;
   background-color: #343E53;
-  transform: translateY(50px);
+  transform: translateY(-60px);
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   opacity: 0;
@@ -70,7 +78,7 @@
 
 .command-helper-container.visible {
   opacity: 1;
-  transform: translateY(7px);
+  transform: translateY(-110px);
   transition: opacity 0.6s ease-in-out, transform 0.3s ease-in;
   pointer-events: auto;
 }

--- a/client/src/styles/chatting.css
+++ b/client/src/styles/chatting.css
@@ -24,6 +24,21 @@
   align-items: center;
 }
 
+.input-and-send-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  width: 100%;
+}
+
+.send-btn-container {
+  padding: 12px 13px;
+  border-radius: 100%;
+  background-color: var(--button);
+}
+
 .input-container {
   height: 45px;
   width: 100%;
@@ -44,7 +59,7 @@
 }
 
 .command-helper-container {
-  width: 100%;
+  width: 90%;
   background-color: #343E53;
   transform: translateY(50px);
   border-top-left-radius: 10px;
@@ -82,10 +97,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-}
-
-.command-helper-guideline-title {
-  padding: 20px;
 }
 
 .command-helper-guideline-item {

--- a/client/src/styles/chatting.css
+++ b/client/src/styles/chatting.css
@@ -50,7 +50,6 @@
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
   opacity: 0;
-  transition: opacity 0.2s ease-out, transform 0.2s ease-in;
   pointer-events: none;
 }
 
@@ -83,4 +82,14 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.command-helper-guideline-title {
+  padding: 20px;
+}
+
+.command-helper-guideline-item {
+  padding: 20px;
+  display: flex;
+  gap: 5px;
 }

--- a/client/src/styles/chatting.css
+++ b/client/src/styles/chatting.css
@@ -14,6 +14,7 @@
 
 .chatbox-container {
   padding: 30px 70px;
+  box-sizing: border-box;
   height: calc(100vh - 100px);
   background-color: var(--backgroundColor);
   overflow: auto;
@@ -21,4 +22,23 @@
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
+}
+
+.input-container {
+  height: 35px;
+  width: 100%;
+  padding: 0 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 12px;
+  background-color: var(--componentColor);
+}
+
+.input-container input {
+  all: unset;
+  font: inherit;
+  color: inherit;
+  box-sizing: border-box;
+  width: 100%;
 }

--- a/client/src/styles/chatting.css
+++ b/client/src/styles/chatting.css
@@ -1,0 +1,24 @@
+.chatting-page {
+  height: 100vh;
+  flex-grow: 1;
+}
+
+.chatting-header {
+  padding: 0 70px;
+  height: 100px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  background-color: var(--componentColor);
+}
+
+.chatbox-container {
+  padding: 30px 70px;
+  height: calc(100vh - 100px);
+  background-color: var(--backgroundColor);
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+}


### PR DESCRIPTION
This pull request creates the initial chat layout in the course page. A new tab is added to the sidebar which allows the user to navigate to the new section. Using the "@" character, the user can either begin a ping call or a command bot call. A new tab appears above the input container showing guidelines on how to use the command bot.

This Pull Request:
- Creates a new react route for the chatting page
- Added a chatting icon in the sidebar which navigates the user to the new page
- Created the input container for the text, using the "@" character as the first character in the input gives the options of using the commandBot or ping.
- On selection of either commandBot or ping, it is appended to the input, and the user is free to type anything out to the command input afterwards.
- After the selection of the commandBot, a tab of guidelines appears on top of the text.
- The send button is only accessible to use after at least one character is typed in either in a normal text or a command, reflected with the icon's color.

Upcoming Changes:
- Adding the NLP pipeline to the commandBot for free text input.
- Creating/editing routes to support the requests from the commandBot.

Video Demonstration of Page
https://www.loom.com/share/8b0f396cca754010a5e4e52f759c972f?sid=0609fa4c-b87c-4e6b-b7d3-ea14266c60de